### PR TITLE
Fix duplicate display of generic params in visualize()

### DIFF
--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -55,9 +55,12 @@ def _format_type(tp: type) -> str:
     but strip all module prefixes from the type name as well as the params.
     We may make this configurable in the future.
     """
-    base = tp.__name__ if hasattr(tp, '__name__') else str(tp).split('.')[-1]
-    if get_origin(tp) is not None:
+
+    def get_base(tp: type) -> type:
+        return tp.__name__ if hasattr(tp, '__name__') else str(tp).split('.')[-1]
+
+    if (origin := get_origin(tp)) is not None:
         params = [_format_type(param) for param in get_args(tp)]
-        return f'{base}[{", ".join(params)}]'
+        return f'{get_base(origin)}[{", ".join(params)}]'
     else:
-        return base
+        return get_base(tp)

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -56,7 +56,7 @@ def _format_type(tp: type) -> str:
     We may make this configurable in the future.
     """
 
-    def get_base(tp: type) -> type:
+    def get_base(tp: type) -> str:
         return tp.__name__ if hasattr(tp, '__name__') else str(tp).split('.')[-1]
 
     if (origin := get_origin(tp)) is not None:

--- a/tests/visualize_test.py
+++ b/tests/visualize_test.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from typing import Generic, TypeVar
+
 import sciline as sl
 from sciline.visualize import to_graphviz
 
@@ -14,3 +16,20 @@ def test_can_visualize_graph_with_cycle() -> None:
     pipeline = sl.Pipeline([int_to_float, float_to_int])
     graph = pipeline.build(int)
     to_graphviz(graph)
+
+
+def test_generic_types_formatted_without_prefixes() -> None:
+    T = TypeVar('T')
+
+    class A(sl.Scope[T, int], int):
+        pass
+
+    class B(Generic[T]):
+        pass
+
+    class SubA(A[T]):
+        pass
+
+    assert sl.visualize._format_type(A[float]) == 'A[float]'
+    assert sl.visualize._format_type(SubA[float]) == 'SubA[float]'
+    assert sl.visualize._format_type(B[float]) == 'B[float]'


### PR DESCRIPTION
This was probably broken by unrelated changes to how the graph was stored.