### PR TITLE
Use str repr for param table html repr when `__name__` does not exist

### DIFF
--- a/src/sciline/param_table.py
+++ b/src/sciline/param_table.py
@@ -76,7 +76,10 @@ class ParamTable(Mapping[type, Collection[Any]]):
     def _repr_html_(self) -> str:
         return (
             f"<table><tr><th>{self.row_dim.__name__}</th>"
-            + "".join(f"<th>{k.__name__}</th>" for k in self._columns.keys())
+            + "".join(
+                f"<th>{getattr(k, '__name__', str(k).split('.')[-1])}</th>"
+                for k in self._columns.keys()
+            )
             + "</tr>"
             + "".join(
                 f"<tr><td>{idx}</td>" + "".join(f"<td>{v}</td>" for v in row) + "</tr>"

--- a/src/sciline/param_table.py
+++ b/src/sciline/param_table.py
@@ -71,7 +71,7 @@ class ParamTable(Mapping[type, Collection[Any]]):
         return self._columns.__len__()
 
     def __repr__(self) -> str:
-        return f"ParamTable(row_dim={self.row_dim}, columns={self._columns})"
+        return f"ParamTable(row_dim={self.row_dim.__name__}, columns={self._columns})"
 
     def _repr_html_(self) -> str:
         return (

--- a/src/sciline/series.py
+++ b/src/sciline/series.py
@@ -43,7 +43,7 @@ class Series(Mapping[Key, Value]):
         return self._map[key]
 
     def __repr__(self) -> str:
-        return f"Series(row_dim={self.row_dim}, {self._map})"
+        return f"Series(row_dim={self.row_dim.__name__}, {self._map})"
 
     def _repr_html_(self) -> str:
         return (


### PR DESCRIPTION
This uses the string representation for the html_repr column names in the case where `.__name__` is not defined.
This is the case for `python<3.10`.

One slightly annoying thing is that when you have a parameter defined as `Filename[Sample]`, in py310 the column header will be `Filename`, while in py39 it becomes `Filename[Sample]`.

I could not use the string repr (with module name stripped) for all cases, because when you have a type defined simply as `Filename = NewType('Filename', str)`, then the column name becomes something like `new_type at 0x7f48681074c0>`. In this case it is better to use the `.__name__`.
So we use the name when we can, and the string repr when `.__name__` is not available.

Fixes #38 