### PR TITLE
Cluster generic products when visualizing graph

### DIFF
--- a/src/sciline/typing.py
+++ b/src/sciline/typing.py
@@ -1,7 +1,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Generic, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
 
 
 @dataclass(frozen=True)
@@ -24,3 +36,12 @@ Provider = Callable[..., Any]
 
 Key = Union[type, Item]
 Graph = Dict[Key, Tuple[Provider, Tuple[Key, ...]]]
+
+
+def get_optional(tp: Key) -> Optional[Any]:
+    if get_origin(tp) != Union:
+        return None
+    args = get_args(tp)
+    if len(args) != 2 or type(None) not in args:
+        return None
+    return args[0] if args[1] == type(None) else args[1]  # noqa: E721

--- a/tests/visualize_test.py
+++ b/tests/visualize_test.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 import sciline as sl
 from sciline.visualize import to_graphviz
@@ -33,3 +33,7 @@ def test_generic_types_formatted_without_prefixes() -> None:
     assert sl.visualize._format_type(A[float]).name == 'A[float]'
     assert sl.visualize._format_type(SubA[float]).name == 'SubA[float]'
     assert sl.visualize._format_type(B[float]).name == 'B[float]'
+
+
+def test_optional_types_formatted_as_their_content() -> None:
+    assert sl.visualize._format_type(Optional[float]).name == 'float'

--- a/tests/visualize_test.py
+++ b/tests/visualize_test.py
@@ -36,4 +36,5 @@ def test_generic_types_formatted_without_prefixes() -> None:
 
 
 def test_optional_types_formatted_as_their_content() -> None:
-    assert sl.visualize._format_type(Optional[float]).name == 'float'
+    formatted = sl.visualize._format_type(Optional[float])  # type: ignore[arg-type]
+    assert formatted.name == 'float'


### PR DESCRIPTION
Without this, graphs that make heavy use of generics are pretty unreadable. It is enabled by default.