### PR TITLE
fix: make names in the graph selectable in jupyter

### DIFF
--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -15,10 +15,24 @@ from typing import (
     get_origin,
 )
 
-from graphviz import Digraph
+import graphviz
 
 from .pipeline import Pipeline, SeriesProvider
 from .typing import Graph, Item, Key, get_optional
+
+
+class Digraph(graphviz.Digraph):  # type: ignore[misc]
+    '''Replace the default `_repr_mimebundle_` implementation from graphviz.Digraph.
+    The default implementation does not return a 'text/html' mimetype.
+    The 'image/svg+xml' mimetype renders as an <img> node in Jupyter.
+    We want graphs to render a <svg> node to enable text selection in the graph.
+    '''
+
+    def _repr_mimebundle_(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        data = super()._repr_mimebundle_(*args, **kwargs)
+        if 'image/svg+xml' in data:
+            data['text/html'] = data['image/svg+xml']
+        return data
 
 
 @dataclass


### PR DESCRIPTION
Currently the text in the rendered task graphs is not selectable.
The reason is that they are rendered into `<img>` tags instead of into `<svg>`.

This change makes them render as a `svg` in Jupyter notebooks and this allows the user to select names of nodes and edges.

This also enables interesting future features such as tool-tips on hover for quickly getting an idea of what a particular node in the graph does.