### PR TITLE
Allow visualization of graphs with missing requirements

### DIFF
--- a/src/sciline/__init__.py
+++ b/src/sciline/__init__.py
@@ -11,14 +11,13 @@ except importlib.metadata.PackageNotFoundError:
 
 from . import scheduler
 from .domain import Scope, ScopeTwoParams
-from .handler import HandleAsBuildTimeException, HandleAsComputeTimeException
-from .param_table import ParamTable
-from .pipeline import (
-    AmbiguousProvider,
-    Pipeline,
-    UnboundTypeVar,
+from .handler import (
+    HandleAsBuildTimeException,
+    HandleAsComputeTimeException,
     UnsatisfiedRequirement,
 )
+from .param_table import ParamTable
+from .pipeline import AmbiguousProvider, Pipeline, UnboundTypeVar
 from .series import Series
 
 __all__ = [
@@ -31,6 +30,8 @@ __all__ = [
     "UnboundTypeVar",
     "UnsatisfiedRequirement",
     "scheduler",
+    "HandleAsBuildTimeException",
+    "HandleAsComputeTimeException",
 ]
 
 del importlib

--- a/src/sciline/__init__.py
+++ b/src/sciline/__init__.py
@@ -11,6 +11,7 @@ except importlib.metadata.PackageNotFoundError:
 
 from . import scheduler
 from .domain import Scope, ScopeTwoParams
+from .handler import HandleAsBuildTimeException, HandleAsComputeTimeException
 from .param_table import ParamTable
 from .pipeline import (
     AmbiguousProvider,

--- a/src/sciline/handler.py
+++ b/src/sciline/handler.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from __future__ import annotations
+
+from typing import Callable, Protocol, Type, TypeVar, Union
+
+from .typing import Item
+
+T = TypeVar('T')
+
+
+class UnsatisfiedRequirement(Exception):
+    """Raised when a type cannot be provided."""
+
+
+class Handler(Protocol):
+    """Error handling protocol for pipelines."""
+
+    def handle_unsatisfied_requirement(self, tp: Union[Type[T], Item[T]]):
+        ...
+
+
+class HandleAsBuildTimeException(Handler):
+    """
+    Error handler used by default.
+
+    This will raise an exception when building the graph, which is helpful for
+    ensuring that errors are caught early, before starting costly computation.
+    """
+
+    def handle_unsatisfied_requirement(self, tp: Union[Type[T], Item[T]]):
+        """Raise an exception when a type cannot be provided."""
+        raise UnsatisfiedRequirement('No provider found for type', tp)
+
+
+class HandleAsComputeTimeException(Handler):
+    """
+    Error handler used for Pipeline.visualize().
+
+    This avoids raising exceptions when building the graph, which would prevent
+    visualization. This is helpful when visualizing a graph that is not yet complete.
+    """
+
+    def handle_unsatisfied_requirement(
+        self, tp: Union[Type[T], Item[T]]
+    ) -> Callable[[], T]:
+        """Return a function that raises an exception when called."""
+
+        def unsatisfied_sentinel() -> None:
+            raise UnsatisfiedRequirement('No provider found for type', tp)
+
+        return unsatisfied_sentinel

--- a/src/sciline/handler.py
+++ b/src/sciline/handler.py
@@ -13,7 +13,7 @@ class UnsatisfiedRequirement(Exception):
     """Raised when a type cannot be provided."""
 
 
-class Handler(Protocol):
+class ErrorHandler(Protocol):
     """Error handling protocol for pipelines."""
 
     def handle_unsatisfied_requirement(
@@ -22,7 +22,7 @@ class Handler(Protocol):
         ...
 
 
-class HandleAsBuildTimeException(Handler):
+class HandleAsBuildTimeException(ErrorHandler):
     """
     Error handler used by default.
 
@@ -35,7 +35,7 @@ class HandleAsBuildTimeException(Handler):
         raise UnsatisfiedRequirement('No provider found for type', tp)
 
 
-class HandleAsComputeTimeException(Handler):
+class HandleAsComputeTimeException(ErrorHandler):
     """
     Error handler used for Pipeline.visualize().
 

--- a/src/sciline/handler.py
+++ b/src/sciline/handler.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 from __future__ import annotations
 
-from typing import Callable, Protocol, Type, TypeVar, Union
+from typing import Callable, NoReturn, Protocol, Type, TypeVar, Union
 
 from .typing import Item
 
@@ -16,7 +16,9 @@ class UnsatisfiedRequirement(Exception):
 class Handler(Protocol):
     """Error handling protocol for pipelines."""
 
-    def handle_unsatisfied_requirement(self, tp: Union[Type[T], Item[T]]):
+    def handle_unsatisfied_requirement(
+        self, tp: Union[Type[T], Item[T]]
+    ) -> Callable[[], T]:
         ...
 
 
@@ -28,7 +30,7 @@ class HandleAsBuildTimeException(Handler):
     ensuring that errors are caught early, before starting costly computation.
     """
 
-    def handle_unsatisfied_requirement(self, tp: Union[Type[T], Item[T]]):
+    def handle_unsatisfied_requirement(self, tp: Union[Type[T], Item[T]]) -> NoReturn:
         """Raise an exception when a type cannot be provided."""
         raise UnsatisfiedRequirement('No provider found for type', tp)
 
@@ -46,7 +48,7 @@ class HandleAsComputeTimeException(Handler):
     ) -> Callable[[], T]:
         """Return a function that raises an exception when called."""
 
-        def unsatisfied_sentinel() -> None:
+        def unsatisfied_sentinel() -> NoReturn:
             raise UnsatisfiedRequirement('No provider found for type', tp)
 
         return unsatisfied_sentinel

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -28,9 +28,9 @@ from sciline.task_graph import TaskGraph
 
 from .domain import Scope, ScopeTwoParams
 from .handler import (
+    ErrorHandler,
     HandleAsBuildTimeException,
     HandleAsComputeTimeException,
-    Handler,
     UnsatisfiedRequirement,
 )
 from .param_table import ParamTable
@@ -446,7 +446,7 @@ class Pipeline:
             self._providers[key] = provider
 
     def _get_provider(
-        self, tp: Union[Type[T], Item[T]], handler: Optional[Handler] = None
+        self, tp: Union[Type[T], Item[T]], handler: Optional[ErrorHandler] = None
     ) -> Tuple[Callable[..., T], Dict[TypeVar, Key]]:
         handler = handler or HandleAsBuildTimeException()
         if (provider := self._providers.get(tp)) is not None:
@@ -487,7 +487,7 @@ class Pipeline:
         self,
         tp: Union[Type[T], Item[T]],
         /,
-        handler: Handler,
+        handler: ErrorHandler,
         search_param_tables: bool = False,
     ) -> Graph:
         """
@@ -684,7 +684,7 @@ class Pipeline:
         keys: type | Iterable[type] | Item[T],
         *,
         scheduler: Optional[Scheduler] = None,
-        handler: Optional[Handler] = None,
+        handler: Optional[ErrorHandler] = None,
     ) -> TaskGraph:
         """
         Return a TaskGraph for the given keys.

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -515,7 +515,8 @@ class Pipeline:
                 graph[tp] = (_param_sentinel, (self._param_name_to_table_key[tp],))
                 continue
             if get_origin(tp) == Series:
-                graph.update(self._build_series(tp))  # type: ignore[arg-type]
+                sub = self._build_series(tp, handler=handler)  # type: ignore[arg-type]
+                graph.update(sub)
                 continue
             if (optional_arg := get_optional(tp)) is not None:
                 try:
@@ -544,7 +545,9 @@ class Pipeline:
                     stack.append(arg)
         return graph
 
-    def _build_series(self, tp: Type[Series[KeyType, ValueType]]) -> Graph:
+    def _build_series(
+        self, tp: Type[Series[KeyType, ValueType]], handler: ErrorHandler
+    ) -> Graph:
         """
         Build (sub)graph for a Series type implementing ParamTable-based functionality.
 
@@ -604,9 +607,7 @@ class Pipeline:
         value_type: Type[ValueType]
         index_name, value_type = get_args(tp)
 
-        subgraph = self.build(
-            value_type, search_param_tables=True, handler=HandleAsBuildTimeException()
-        )
+        subgraph = self.build(value_type, search_param_tables=True, handler=handler)
 
         replicator: ReplicatorBase[KeyType]
         if (

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -298,14 +298,6 @@ class SeriesProvider(Generic[KeyType]):
         return Series(self.row_dim, dict(zip(self.labels, vals)))
 
 
-class unsatisfied_sentinel:
-    def __init__(self, tp: Type[T]) -> None:
-        self.tp = tp
-
-    def __call__(self) -> None:
-        raise UnsatisfiedRequirement(f'No provider found for type {self.tp}')
-
-
 class _param_sentinel:
     ...
 

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -487,6 +487,7 @@ class Pipeline:
         self,
         tp: Union[Type[T], Item[T]],
         /,
+        *,
         handler: ErrorHandler,
         search_param_tables: bool = False,
     ) -> Graph:

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -27,6 +27,12 @@ from typing import (
 from sciline.task_graph import TaskGraph
 
 from .domain import Scope, ScopeTwoParams
+from .handler import (
+    HandleAsBuildTimeException,
+    HandleAsComputeTimeException,
+    Handler,
+    UnsatisfiedRequirement,
+)
 from .param_table import ParamTable
 from .scheduler import Scheduler
 from .series import Series
@@ -37,10 +43,6 @@ KeyType = TypeVar('KeyType')
 ValueType = TypeVar('ValueType')
 IndexType = TypeVar('IndexType')
 LabelType = TypeVar('LabelType')
-
-
-class UnsatisfiedRequirement(Exception):
-    """Raised when a type cannot be provided."""
 
 
 class UnboundTypeVar(Exception):
@@ -296,6 +298,14 @@ class SeriesProvider(Generic[KeyType]):
         return Series(self.row_dim, dict(zip(self.labels, vals)))
 
 
+class unsatisfied_sentinel:
+    def __init__(self, tp: Type[T]) -> None:
+        self.tp = tp
+
+    def __call__(self) -> None:
+        raise UnsatisfiedRequirement(f'No provider found for type {self.tp}')
+
+
 class _param_sentinel:
     ...
 
@@ -444,8 +454,9 @@ class Pipeline:
             self._providers[key] = provider
 
     def _get_provider(
-        self, tp: Union[Type[T], Item[T]]
+        self, tp: Union[Type[T], Item[T]], handler: Optional[Handler] = None
     ) -> Tuple[Callable[..., T], Dict[TypeVar, Key]]:
+        handler = handler or HandleAsBuildTimeException()
         if (provider := self._providers.get(tp)) is not None:
             return provider, {}
         elif (origin := get_origin(tp)) is not None and (
@@ -477,10 +488,15 @@ class Pipeline:
                 return provider, bound
             elif len(matches) > 1:
                 raise AmbiguousProvider("Multiple providers found for type", tp)
-        raise UnsatisfiedRequirement("No provider found for type", tp)
+
+        return handler.handle_unsatisfied_requirement(tp), {}
 
     def build(
-        self, tp: Union[Type[T], Item[T]], /, search_param_tables: bool = False
+        self,
+        tp: Union[Type[T], Item[T]],
+        /,
+        handler: Handler,
+        search_param_tables: bool = False,
     ) -> Graph:
         """
         Return a dict of providers required for building the requested type `tp`.
@@ -511,7 +527,9 @@ class Pipeline:
             if (optional_arg := get_optional(tp)) is not None:
                 try:
                     optional_subgraph = self.build(
-                        optional_arg, search_param_tables=search_param_tables
+                        optional_arg,
+                        search_param_tables=search_param_tables,
+                        handler=HandleAsBuildTimeException(),
                     )
                 except UnsatisfiedRequirement:
                     graph[tp] = (provide_none, ())
@@ -520,7 +538,7 @@ class Pipeline:
                     graph.update(optional_subgraph)
                 continue
             provider: Callable[..., T]
-            provider, bound = self._get_provider(tp)
+            provider, bound = self._get_provider(tp, handler=handler)
             tps = get_type_hints(provider)
             args = tuple(
                 _bind_free_typevars(t, bound=bound)
@@ -593,7 +611,9 @@ class Pipeline:
         value_type: Type[ValueType]
         index_name, value_type = get_args(tp)
 
-        subgraph = self.build(value_type, search_param_tables=True)
+        subgraph = self.build(
+            value_type, search_param_tables=True, handler=HandleAsBuildTimeException()
+        )
 
         replicator: ReplicatorBase[KeyType]
         if (
@@ -665,13 +685,14 @@ class Pipeline:
         kwargs:
             Keyword arguments passed to :py:class:`graphviz.Digraph`.
         """
-        return self.get(tp).visualize(**kwargs)
+        return self.get(tp, handler=HandleAsComputeTimeException()).visualize(**kwargs)
 
     def get(
         self,
         keys: type | Iterable[type] | Item[T],
         *,
         scheduler: Optional[Scheduler] = None,
+        handler: Optional[Handler] = None,
     ) -> TaskGraph:
         """
         Return a TaskGraph for the given keys.
@@ -685,14 +706,21 @@ class Pipeline:
             Optional scheduler to use for computing the result. If not given, a
             :py:class:`NaiveScheduler` is used if `dask` is not installed,
             otherwise dask's threaded scheduler is used.
+        handler:
+            Handler for unsatisfied requirements. If not provided,
+            :py:class:`HandleAsBuildTimeException` is used, which raises an exception.
+            During development and debugging it can be helpful to use a handler that
+            raises an exception only when the graph is computed. This can be achieved
+            by passing :py:class:`HandleAsComputeTimeException` as the handler.
         """
+        handler = handler or HandleAsBuildTimeException()
         if _is_multiple_keys(keys):
             keys = tuple(keys)  # type: ignore[arg-type]
             graph: Graph = {}
             for t in keys:
-                graph.update(self.build(t))
+                graph.update(self.build(t, handler=handler))
         else:
-            graph = self.build(keys)  # type: ignore[arg-type]
+            graph = self.build(keys, handler=handler)  # type: ignore[arg-type]
         return TaskGraph(
             graph=graph, keys=keys, scheduler=scheduler  # type: ignore[arg-type]
         )

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -113,6 +113,7 @@ def _add_subgraph(graph: FormattedGraph, dot: Digraph, subgraph: Digraph) -> Non
                 shape='box3d' if ret.collapsed else 'rectangle',
                 color='red',
                 fontcolor='red',  # Set text color to red
+                style='dashed',
             )
         else:
             subgraph.node(

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -17,6 +17,7 @@ from typing import (
 
 import graphviz
 
+from .handler import HandleAsComputeTimeException
 from .pipeline import Pipeline, SeriesProvider
 from .typing import Graph, Item, Key, get_optional
 
@@ -104,13 +105,24 @@ def _to_subgraphs(graph: FormattedGraph) -> Dict[str, FormattedGraph]:
 
 def _add_subgraph(graph: FormattedGraph, dot: Digraph, subgraph: Digraph) -> None:
     for p, (p_name, args, ret) in graph.items():
-        subgraph.node(
-            ret.name, ret.name, shape='box3d' if ret.collapsed else 'rectangle'
-        )
+        unsatisfied = f'{_qualname(HandleAsComputeTimeException.handle_unsatisfied_requirement)}.<locals>.unsatisfied_sentinel'  # noqa: E501
+        if p_name == unsatisfied:
+            subgraph.node(
+                ret.name,
+                ret.name,
+                shape='box3d' if ret.collapsed else 'rectangle',
+                color='red',
+                fontcolor='red',  # Set text color to red
+            )
+        else:
+            subgraph.node(
+                ret.name, ret.name, shape='box3d' if ret.collapsed else 'rectangle'
+            )
         # Do not draw dummy providers created by Pipeline when setting instances
         if p_name in (
             f'{_qualname(Pipeline.__setitem__)}.<locals>.<lambda>',
             f'{_qualname(Pipeline.set_param_table)}.<locals>.<lambda>',
+            unsatisfied,
         ):
             continue
         # Do not draw the internal provider gathering index-dependent results into

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -617,7 +617,7 @@ def test_building_graph_with_cycle_succeeds() -> None:
         return int(x)
 
     pipeline = sl.Pipeline([f, g])
-    _ = pipeline.build(int)
+    _ = pipeline.get(int)
 
 
 def test_computing_graph_with_cycle_raises_CycleError() -> None:
@@ -907,3 +907,13 @@ def test_prioritizes_specialized_provider_raises() -> None:
 
     with pytest.raises(sl.UnsatisfiedRequirement):
         pl.compute(C[B, A])
+
+
+def test_compute_time_handler_allows_for_building_but_not_computing() -> None:
+    def func(x: int) -> float:
+        return 0.5 * x
+
+    pipeline = sl.Pipeline([func])
+    graph = pipeline.get(float, handler=sl.HandleAsComputeTimeException())
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        graph.compute()

--- a/tests/pipeline_with_param_table_test.py
+++ b/tests/pipeline_with_param_table_test.py
@@ -594,3 +594,14 @@ def test_params_in_table_can_be_generic() -> None:
 
     assert pipeline.compute(Str[int]) == Str[int]('1,2')
     assert pipeline.compute(Str[float]) == Str[float]('1.5,2.5')
+
+
+def test_compute_time_handler_works_alongside_param_table() -> None:
+    Missing = NewType("Missing", str)
+
+    def process(x: float, missing: Missing) -> str:
+        return str(x) + missing
+
+    pl = sl.Pipeline([process])
+    pl.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
+    pl.get(sl.Series[int, str], handler=sl.HandleAsComputeTimeException())

--- a/tests/task_graph_test.py
+++ b/tests/task_graph_test.py
@@ -13,7 +13,7 @@ def as_float(x: int) -> float:
 
 def make_task_graph() -> Graph:
     pl = sl.Pipeline([as_float], params={int: 1})
-    return pl.build(float)
+    return pl.build(float, handler=sl.HandleAsBuildTimeException())
 
 
 def test_default_scheduler_is_dask_when_dask_available() -> None:

--- a/tests/visualize_test.py
+++ b/tests/visualize_test.py
@@ -3,7 +3,6 @@
 from typing import Generic, Optional, TypeVar
 
 import sciline as sl
-from sciline.visualize import to_graphviz
 
 
 def test_can_visualize_graph_with_cycle() -> None:
@@ -14,8 +13,16 @@ def test_can_visualize_graph_with_cycle() -> None:
         return int(x)
 
     pipeline = sl.Pipeline([int_to_float, float_to_int])
-    graph = pipeline.build(int)
-    to_graphviz(graph)
+    graph = pipeline.get(int)
+    graph.visualize()
+
+
+def test_can_visualize_graph_with_unsatisfied_requirements() -> None:
+    def int_to_float(x: int) -> float:
+        return float(x)
+
+    pipeline = sl.Pipeline([int_to_float])
+    pipeline.visualize(int)
 
 
 def test_generic_types_formatted_without_prefixes() -> None:


### PR DESCRIPTION
Fixes #79.

This avoids wasting a lot of time when working with scientists to draft a workflow. Previously I had to add a ton of dummy providers. I think this may also be helpful later to highlight which parameters still need to be set.

Currently this only works for the non-param-table case, we can add support for that later.

Example:
![image](https://github.com/scipp/sciline/assets/12912489/fb4ad120-ba22-44ba-91a9-39f1074c9f6f)
