### PR TITLE
Print the matching providers as part of the error message

### DIFF
--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -479,7 +479,11 @@ class Pipeline:
                 }
                 return provider, bound
             elif len(matches) > 1:
-                raise AmbiguousProvider("Multiple providers found for type", tp)
+                matching_providers = [m[1].__name__ for m in matches]
+                raise AmbiguousProvider(
+                    f"Multiple providers found for type {tp}."
+                    f" Matching providers are: {matching_providers}."
+                )
 
         return handler.handle_unsatisfied_requirement(tp), {}
 


### PR DESCRIPTION
This helps to debug pipelines when you get the error message `Multiple providers found for type XXX`, but you don't know which are the providers that are overlapping.