### PR TITLE
feat: add check to determine if graph uses all avaliable parameters

### DIFF
--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -656,15 +656,15 @@ class Pipeline:
         return graph
 
     @overload
-    def compute(self, tp: Type[T], check: bool) -> T:
+    def compute(self, tp: Type[T], check: bool = ...) -> T:
         ...
 
     @overload
-    def compute(self, tp: Iterable[Type[T]], check: bool) -> Dict[Type[T], T]:
+    def compute(self, tp: Iterable[Type[T]], check: bool = ...) -> Dict[Type[T], T]:
         ...
 
     @overload
-    def compute(self, tp: Item[T], check: bool) -> T:
+    def compute(self, tp: Item[T], check: bool = ...) -> T:
         ...
 
     def compute(self, tp: type | Iterable[type] | Item[T], check: bool = False) -> Any:
@@ -705,7 +705,7 @@ class Pipeline:
         *,
         scheduler: Optional[Scheduler] = None,
         handler: Optional[ErrorHandler] = None,
-        check=False,
+        check: bool = False,
     ) -> TaskGraph:
         """
         Return a TaskGraph for the given keys.

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -922,7 +922,8 @@ def test_compute_time_handler_allows_for_building_but_not_computing() -> None:
 def test_pipeline_with_unused_parameter_raises_if_check() -> None:
     Unused = NewType('Unused', str)
     pipeline = sl.Pipeline([int_to_float, make_int])
+    assert pipeline.compute(float, check=True) == 1.5
     pipeline[Unused] = 'Should raise'
-    assert pipeline.compute(float) == 1.5
     with pytest.raises(RuntimeError):
         assert pipeline.compute(float, check=True) == 1.5
+    assert pipeline.compute(float) == 1.5

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -917,3 +917,12 @@ def test_compute_time_handler_allows_for_building_but_not_computing() -> None:
     graph = pipeline.get(float, handler=sl.HandleAsComputeTimeException())
     with pytest.raises(sl.UnsatisfiedRequirement):
         graph.compute()
+
+
+def test_pipeline_with_unused_parameter_raises_if_check() -> None:
+    Unused = NewType('Unused', str)
+    pipeline = sl.Pipeline([int_to_float, make_int])
+    pipeline[Unused] = 'Should raise'
+    assert pipeline.compute(float) == 1.5
+    with pytest.raises(RuntimeError):
+        assert pipeline.compute(float, check=True) == 1.5


### PR DESCRIPTION
Fixes [#43](https://github.com/scipp/sciline/issues/43).

I wasn't sure if this should be added to the task graph rather than to the pipeline. What do you think?

I think there is also an opportunity here to extract the functionality of retrieving all providers to a helper method, it's also used in the `_repr_html_` for example, but I didn't want to complicate things for now.