### PR TITLE
Revert "fix: make names in the graph selectable in jupyter"

### DIFF
--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -15,25 +15,11 @@ from typing import (
     get_origin,
 )
 
-import graphviz
+from graphviz import Digraph
 
 from .handler import HandleAsComputeTimeException
 from .pipeline import Pipeline, SeriesProvider
 from .typing import Graph, Item, Key, get_optional
-
-
-class Digraph(graphviz.Digraph):  # type: ignore[misc]
-    '''Replace the default `_repr_mimebundle_` implementation from graphviz.Digraph.
-    The default implementation does not return a 'text/html' mimetype.
-    The 'image/svg+xml' mimetype renders as an <img> node in Jupyter.
-    We want graphs to render a <svg> node to enable text selection in the graph.
-    '''
-
-    def _repr_mimebundle_(self, *args, **kwargs):  # type: ignore[no-untyped-def]
-        data = super()._repr_mimebundle_(*args, **kwargs)
-        if 'image/svg+xml' in data:
-            data['text/html'] = data['image/svg+xml']
-        return data
 
 
 @dataclass


### PR DESCRIPTION
Reverts scipp/sciline#64.

While being able to select names is great, the solution from #64 breaks something more important: The graphs cannot be opened in a tab any more (or saved), and are displayed at 100%, making documentation partially unreadable.

We should ultimately try to find a solution that addresses both, but for now I will simply revert this, since it affects "production" docs.