### PR TITLE
Add pipeline copy method

### DIFF
--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -323,7 +323,7 @@ class Pipeline:
             Dictionary of concrete values to provide for types.
         """
         self._copy_providers = list(providers or [])
-        self._copy_params = {}
+        self._copy_params: Dict[type, Any] = {}
 
         self._providers: Dict[Key, Provider] = {}
         self._subproviders: Dict[type, Dict[Tuple[Key | TypeVar, ...], Provider]] = {}

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -801,9 +801,7 @@ class Pipeline:
         """
         out = Pipeline()
         out._providers = self._providers.copy()
-        out._subproviders = {
-            k: {kk: vv for kk, vv in v.items()} for k, v in self._subproviders.items()
-        }
+        out._subproviders = {k: v.copy() for k, v in self._subproviders.items()}
         out._param_tables = self._param_tables.copy()
         out._param_name_to_table_key = self._param_name_to_table_key.copy()
         return out

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -322,6 +322,9 @@ class Pipeline:
         params:
             Dictionary of concrete values to provide for types.
         """
+        self._original_providers = list(providers or [])
+        self._original_params = (params or {}).copy()
+
         self._providers: Dict[Key, Provider] = {}
         self._subproviders: Dict[type, Dict[Tuple[Key | TypeVar, ...], Provider]] = {}
         self._param_tables: Dict[Key, ParamTable] = {}
@@ -794,3 +797,15 @@ class Pipeline:
         if not return_tuple:
             return results[0]
         return results
+
+    def copy(self) -> Pipeline:
+        """
+        Make a copy of the pipeline.
+        """
+        out = Pipeline(
+            providers=self._original_providers,
+            params=self._original_params,
+        )
+        for table in self._param_tables.values():
+            out.set_param_table(table)
+        return out

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -322,8 +322,8 @@ class Pipeline:
         params:
             Dictionary of concrete values to provide for types.
         """
-        self._original_providers = list(providers or [])
-        self._original_params = (params or {}).copy()
+        self._copy_providers = list(providers or [])
+        self._copy_params = {}
 
         self._providers: Dict[Key, Provider] = {}
         self._subproviders: Dict[type, Dict[Tuple[Key | TypeVar, ...], Provider]] = {}
@@ -347,6 +347,7 @@ class Pipeline:
         if (key := get_type_hints(provider).get('return')) is None:
             raise ValueError(f'Provider {provider} lacks type-hint for return value')
         self._set_provider(key, provider)
+        self._copy_providers.append(provider)
 
     def __setitem__(self, key: Type[T], param: T) -> None:
         """
@@ -390,6 +391,7 @@ class Pipeline:
                 f'Key {key} incompatible to value {param} of type {type(param)}'
             )
         self._set_provider(key, lambda: param)
+        self._copy_params[key] = param
 
     def set_param_table(self, params: ParamTable) -> None:
         """
@@ -803,8 +805,8 @@ class Pipeline:
         Make a copy of the pipeline.
         """
         out = Pipeline(
-            providers=self._original_providers,
-            params=self._original_params,
+            providers=self._copy_providers,
+            params=self._copy_params,
         )
         for table in self._param_tables.values():
             out.set_param_table(table)

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -805,3 +805,6 @@ class Pipeline:
         out._param_tables = self._param_tables.copy()
         out._param_name_to_table_key = self._param_name_to_table_key.copy()
         return out
+
+    def __copy__(self) -> Pipeline:
+        return self.copy()

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1050,3 +1050,47 @@ def test_pipeline_copy_after_setitem() -> None:
     b = a.copy()
     assert b.compute(int) == 99
     assert b.compute(float) == 49.5
+
+
+def test_pipeline_insert_on_copy_does_not_affect_original() -> None:
+    a = sl.Pipeline([int_to_float])
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        a.compute(int)
+    b = a.copy()
+    b.insert(make_int)
+    assert b.compute(int) == 3
+    assert b.compute(float) == 1.5
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        a.compute(int)
+
+
+def test_pipeline_insert_on_original_does_not_affect_copy() -> None:
+    a = sl.Pipeline([int_to_float])
+    b = a.copy()
+    a.insert(make_int)
+    assert a.compute(int) == 3
+    assert a.compute(float) == 1.5
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        b.compute(int)
+
+
+def test_pipeline_setitem_on_copy_does_not_affect_original() -> None:
+    a = sl.Pipeline([int_to_float])
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        a.compute(int)
+    b = a.copy()
+    b[int] = 99
+    assert b.compute(int) == 99
+    assert b.compute(float) == 49.5
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        a.compute(int)
+
+
+def test_pipeline_setitem_on_original_does_not_affect_copy() -> None:
+    a = sl.Pipeline([int_to_float])
+    b = a.copy()
+    a[int] = 99
+    assert a.compute(int) == 99
+    assert a.compute(float) == 49.5
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        b.compute(int)

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1029,6 +1029,15 @@ def test_pipeline_copy_simple() -> None:
     assert b.compute(float) == 1.5
 
 
+def test_pipeline_copy_dunder() -> None:
+    a = sl.Pipeline([int_to_float, make_int])
+    from copy import copy
+
+    b = copy(a)
+    assert b.compute(int) == 3
+    assert b.compute(float) == 1.5
+
+
 def test_pipeline_copy_with_params() -> None:
     a = sl.Pipeline([int_to_float], params={int: 99})
     b = a.copy()
@@ -1139,12 +1148,13 @@ def test_pipeline_with_generics_setitem_on_original_does_not_affect_copy() -> No
     ) -> Result:
         return Result(sample + background)
 
-    providers = [square, process]
-    params = {
-        RawData[Sample]: 5,
-        RawData[Background]: 2,
-    }
-    a = sl.Pipeline(providers, params=params)
+    a = sl.Pipeline(
+        [square, process],
+        params={
+            RawData[Sample]: 5,
+            RawData[Background]: 2,
+        },
+    )
     assert a.compute(Result) == 29
     b = a.copy()
     assert b.compute(Result) == 29
@@ -1174,12 +1184,13 @@ def test_pipeline_with_generics_setitem_on_copy_does_not_affect_original() -> No
     ) -> Result:
         return Result(sample + background)
 
-    providers = [square, process]
-    params = {
-        RawData[Sample]: 5,
-        RawData[Background]: 2,
-    }
-    a = sl.Pipeline(providers, params=params)
+    a = sl.Pipeline(
+        [square, process],
+        params={
+            RawData[Sample]: 5,
+            RawData[Background]: 2,
+        },
+    )
     assert a.compute(Result) == 29
     b = a.copy()
     assert b.compute(Result) == 29

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1025,28 +1025,28 @@ def test_compute_time_handler_allows_for_building_but_not_computing() -> None:
 def test_pipeline_copy_simple() -> None:
     a = sl.Pipeline([int_to_float, make_int])
     b = a.copy()
-    assert b.compute(float) == 1.5
     assert b.compute(int) == 3
+    assert b.compute(float) == 1.5
 
 
 def test_pipeline_copy_with_params() -> None:
     a = sl.Pipeline([int_to_float], params={int: 99})
     b = a.copy()
-    assert b.compute(float) == 1.5
     assert b.compute(int) == 99
+    assert b.compute(float) == 49.5
 
 
 def test_pipeline_copy_after_insert() -> None:
     a = sl.Pipeline([int_to_float])
     a.insert(make_int)
     b = a.copy()
-    assert b.compute(float) == 1.5
     assert b.compute(int) == 3
+    assert b.compute(float) == 1.5
 
 
 def test_pipeline_copy_after_setitem() -> None:
     a = sl.Pipeline([int_to_float])
     a[int] = 99
     b = a.copy()
-    assert b.compute(float) == 1.5
     assert b.compute(int) == 99
+    assert b.compute(float) == 49.5

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1020,3 +1020,33 @@ def test_compute_time_handler_allows_for_building_but_not_computing() -> None:
     graph = pipeline.get(float, handler=sl.HandleAsComputeTimeException())
     with pytest.raises(sl.UnsatisfiedRequirement):
         graph.compute()
+
+
+def test_pipeline_copy_simple() -> None:
+    a = sl.Pipeline([int_to_float, make_int])
+    b = a.copy()
+    assert b.compute(float) == 1.5
+    assert b.compute(int) == 3
+
+
+def test_pipeline_copy_with_params() -> None:
+    a = sl.Pipeline([int_to_float], params={int: 99})
+    b = a.copy()
+    assert b.compute(float) == 1.5
+    assert b.compute(int) == 99
+
+
+def test_pipeline_copy_after_insert() -> None:
+    a = sl.Pipeline([int_to_float])
+    a.insert(make_int)
+    b = a.copy()
+    assert b.compute(float) == 1.5
+    assert b.compute(int) == 3
+
+
+def test_pipeline_copy_after_setitem() -> None:
+    a = sl.Pipeline([int_to_float])
+    a[int] = 99
+    b = a.copy()
+    assert b.compute(float) == 1.5
+    assert b.compute(int) == 99

--- a/tests/pipeline_with_param_table_test.py
+++ b/tests/pipeline_with_param_table_test.py
@@ -620,3 +620,21 @@ def test_pipeline_copy_with_param_table() -> None:
     a.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
     b = a.copy()
     assert b.compute(sl.Series[int, float]) == sl.Series(int, {0: 1.0, 1: 2.0, 2: 3.0})
+
+
+def test_pipeline_set_param_table_on_original_does_not_affect_copy() -> None:
+    a = sl.Pipeline()
+    b = a.copy()
+    a.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
+    assert a.compute(sl.Series[int, float]) == sl.Series(int, {0: 1.0, 1: 2.0, 2: 3.0})
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        b.compute(sl.Series[int, float])
+
+
+def test_pipeline_set_param_table_on_copy_does_not_affect_original() -> None:
+    a = sl.Pipeline()
+    b = a.copy()
+    b.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
+    assert b.compute(sl.Series[int, float]) == sl.Series(int, {0: 1.0, 1: 2.0, 2: 3.0})
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        a.compute(sl.Series[int, float])

--- a/tests/pipeline_with_param_table_test.py
+++ b/tests/pipeline_with_param_table_test.py
@@ -613,3 +613,10 @@ def test_param_table_column_and_param_of_same_type_can_coexist() -> None:
     pl.set_param_table(sl.ParamTable(int, {float: [2.0, 3.0]}))
     assert pl.compute(float) == 1.0
     assert pl.compute(sl.Series[int, float]) == sl.Series(int, {0: 2.0, 1: 3.0})
+
+
+def test_pipeline_copy_with_param_table() -> None:
+    a = sl.Pipeline()
+    a.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
+    b = a.copy()
+    assert b.compute(sl.Series[int, float]) == sl.Series(int, {0: 1.0, 1: 2.0, 2: 3.0})


### PR DESCRIPTION
This makes it possible to make a copy of an existing pipeline.
One can then, for example modify the parameters of the new pipeline.