### PR TITLE
copier update & fix unpinned nightly

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 8cfdb1b
+_commit: bba4103
 _src_path: gh:scipp/copier_template
 description: Build scientific pipelines for your data
 max_python: '3.12'
@@ -10,4 +10,4 @@ orgname: scipp
 prettyname: Sciline
 projectname: sciline
 related_projects: Scipp
-year: 2023
+year: 2024

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2023, Scipp contributors (https://github.com/scipp)
+Copyright (c) 2024, Scipp contributors (https://github.com/scipp)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath('.'))
 
 # General information about the project.
 project = u'Sciline'
-copyright = u'2023 Scipp contributors'
+copyright = u'2024 Scipp contributors'
 author = u'Scipp contributors'
 
 html_show_sourcelink = True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,9 +39,9 @@ six==1.16.0
     # via asttokens
 stack-data==0.6.3
     # via ipython
-traitlets==5.14.0
+traitlets==5.14.1
     # via
     #   ipython
     #   matplotlib-inline
-wcwidth==0.2.12
+wcwidth==0.2.13
     # via prompt-toolkit

--- a/requirements/basetest.txt
+++ b/requirements/basetest.txt
@@ -11,13 +11,13 @@ graphviz==0.20.1
     # via -r basetest.in
 iniconfig==2.0.0
     # via pytest
-numpy==1.26.2
+numpy==1.26.3
     # via -r basetest.in
 packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.3
+pytest==7.4.4
     # via -r basetest.in
 tomli==2.0.1
     # via pytest

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,15 +55,15 @@ jupyter-events==0.9.0
     # via jupyter-server
 jupyter-lsp==2.2.1
     # via jupyterlab
-jupyter-server==2.12.1
+jupyter-server==2.12.2
     # via
     #   jupyter-lsp
     #   jupyterlab
     #   jupyterlab-server
     #   notebook-shim
-jupyter-server-terminals==0.5.0
+jupyter-server-terminals==0.5.1
     # via jupyter-server
-jupyterlab==4.0.9
+jupyterlab==4.0.10
     # via -r dev.in
 jupyterlab-server==2.25.2
     # via jupyterlab
@@ -83,13 +83,13 @@ prometheus-client==0.19.0
     # via jupyter-server
 pycparser==2.21
     # via cffi
-pydantic==2.5.2
+pydantic==2.5.3
     # via copier
-pydantic-core==2.14.5
+pydantic-core==2.14.6
     # via pydantic
 python-json-logger==2.0.7
     # via jupyter-events
-pyyaml-include==1.3.1
+pyyaml-include==1.3.2
     # via copier
 questionary==2.0.1
     # via copier
@@ -111,7 +111,7 @@ terminado==0.18.0
     #   jupyter-server-terminals
 toposort==1.10
     # via pip-compile-multi
-types-python-dateutil==2.8.19.14
+types-python-dateutil==2.8.19.20240106
     # via arrow
 uri-template==1.3.0
     # via jsonschema

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,9 +8,9 @@
 -r base.txt
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-alabaster==0.7.13
+alabaster==0.7.15
     # via sphinx
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
@@ -28,7 +28,7 @@ certifi==2023.11.17
     # via requests
 charset-normalizer==3.3.2
     # via requests
-comm==0.2.0
+comm==0.2.1
     # via ipykernel
 debugpy==1.8.0
     # via ipykernel
@@ -40,7 +40,7 @@ docutils==0.20.1
     #   nbsphinx
     #   pydata-sphinx-theme
     #   sphinx
-fastjsonschema==2.19.0
+fastjsonschema==2.19.1
     # via nbformat
 graphviz==0.20.1
     # via -r docs.in
@@ -48,12 +48,12 @@ idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==7.0.0
+importlib-metadata==7.0.1
     # via
     #   jupyter-client
     #   nbconvert
     #   sphinx
-ipykernel==6.27.1
+ipykernel==6.28.0
     # via -r docs.in
 jinja2==3.1.2
     # via
@@ -63,13 +63,13 @@ jinja2==3.1.2
     #   sphinx
 jsonschema==4.20.0
     # via nbformat
-jsonschema-specifications==2023.11.2
+jsonschema-specifications==2023.12.1
     # via jsonschema
 jupyter-client==8.6.0
     # via
     #   ipykernel
     #   nbclient
-jupyter-core==5.5.0
+jupyter-core==5.7.1
     # via
     #   ipykernel
     #   jupyter-client
@@ -96,7 +96,7 @@ myst-parser==2.0.0
     # via -r docs.in
 nbclient==0.9.0
     # via nbconvert
-nbconvert==7.12.0
+nbconvert==7.14.0
     # via nbsphinx
 nbformat==5.9.2
     # via
@@ -119,7 +119,7 @@ platformdirs==4.1.0
     # via jupyter-core
 psutil==5.9.7
     # via ipykernel
-pydata-sphinx-theme==0.14.4
+pydata-sphinx-theme==0.15.1
     # via -r docs.in
 python-dateutil==2.8.2
     # via jupyter-client
@@ -129,13 +129,13 @@ pyzmq==25.1.2
     # via
     #   ipykernel
     #   jupyter-client
-referencing==0.32.0
+referencing==0.32.1
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via sphinx
-rpds-py==0.15.2
+rpds-py==0.16.2
     # via
     #   jsonschema
     #   referencing

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -6,7 +6,7 @@
 #    pip-compile-multi
 #
 -r test.txt
-mypy==1.7.1
+mypy==1.8.0
     # via -r mypy.in
 mypy-extensions==1.0.0
     # via mypy

--- a/requirements/test-dask.txt
+++ b/requirements/test-dask.txt
@@ -14,7 +14,7 @@ dask==2023.12.1
     # via -r test-dask.in
 fsspec==2023.12.2
     # via dask
-importlib-metadata==7.0.0
+importlib-metadata==7.0.1
     # via dask
 locket==1.0.0
     # via partd

--- a/requirements/wheels.txt
+++ b/requirements/wheels.txt
@@ -7,7 +7,7 @@
 #
 build==1.0.3
     # via -r wheels.in
-importlib-metadata==7.0.0
+importlib-metadata==7.0.1
     # via build
 packaging==23.2
     # via build

--- a/src/sciline/__init__.py
+++ b/src/sciline/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 
 # flake8: noqa
 import importlib.metadata

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 import sciline as pkg
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,8 @@ commands = pytest
 [testenv:unpinned]
 description = Test with unpinned dependencies, as a user would install now.
 deps =
+  -r requirements/basetest.txt
   sciline
-  pytest
 commands = pytest
 
 [testenv:docs]


### PR DESCRIPTION
Ran `copier update` and `tox -e deps` with no other changes. This should fixed the failing "unpinned" pipeline (which was missing NumPy when running tests).