### PR TITLE
Support param tables with only index and no columns

### DIFF
--- a/docs/user-guide/parameter-tables.ipynb
+++ b/docs/user-guide/parameter-tables.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "This chapter illustrates how to implement *map* operations with Sciline.\n",
     "\n",
-    "Starting with the model workflow introduced in [Getting Started](getting-started.ipynb), we can replace the fixed `Filename` parameter with a series of filenames listed in a [ParamTable](../generated/classes/ParamTable.rst):"
+    "Starting with the model workflow introduced in [Getting Started](getting-started.ipynb), we can replace the fixed `Filename` parameter with a series of filenames listed in a [ParamTable](../generated/classes/sciline.ParamTable.rst):"
    ]
   },
   {
@@ -314,6 +314,59 @@
    "metadata": {},
    "source": [
     "## More examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using tables for series of parameters\n",
+    "\n",
+    "Sometimes the parameter of interest is the index of a parameter table itself.\n",
+    "If there are no further parameters, the param table may have no columns (aside from the index).\n",
+    "In this case we can bypass the manual creation of a parameter table and use the [Pipeline.set_param_series](../generated/classes/sciline.Pipeline.rst#sciline.Pipeline.set_param_series) function instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import NewType\n",
+    "import sciline as sl\n",
+    "\n",
+    "Param = NewType(\"Param\", int)\n",
+    "Sum = NewType(\"Sum\", float)\n",
+    "\n",
+    "\n",
+    "def compute(x: Param) -> float:\n",
+    "    return 0.5 * x\n",
+    "\n",
+    "\n",
+    "def gather(x: sl.Series[Param, float]) -> Sum:\n",
+    "    return Sum(sum(x.values()))\n",
+    "\n",
+    "\n",
+    "pl = sl.Pipeline([gather, compute])\n",
+    "pl.set_param_series(Param, [1, 4, 9])\n",
+    "pl.visualize(Sum)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that `pl.set_param_series(Param, [1, 4, 9])` above is equivalent to `pl.set_param_table(sl.ParamTable(Param, columns={}, index=[1, 4, 9]))`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pl.compute(Sum)"
    ]
   },
   {

--- a/src/sciline/param_table.py
+++ b/src/sciline/param_table.py
@@ -32,11 +32,16 @@ class ParamTable(Mapping[type, Collection[Any]]):
             generated, as the integer range of the column length.
         """
         sizes = set(len(v) for v in columns.values())
-        if len(sizes) != 1:
+        if len(sizes) > 1:
             raise ValueError(
                 f"Columns in param table must all have same size, got {sizes}"
             )
-        size = sizes.pop()
+        if sizes:
+            size = sizes.pop()
+        elif index is None:
+            raise ValueError("Cannot create param table with zero columns and no index")
+        else:
+            size = len(index)
         if index is not None:
             if len(index) != size:
                 raise ValueError(

--- a/tests/param_table_test.py
+++ b/tests/param_table_test.py
@@ -45,3 +45,9 @@ def test_len_is_number_of_columns() -> None:
 def test_defaults_to_range_index() -> None:
     pt = sl.ParamTable(row_dim=int, columns={float: [1.0, 2.0, 3.0]})
     assert pt.index == [0, 1, 2]
+
+
+def test_index_with_no_columns() -> None:
+    pt = sl.ParamTable(row_dim=int, columns={}, index=[1, 2, 3])
+    assert pt.index == [1, 2, 3]
+    assert len(pt) == 0

--- a/tests/pipeline_with_optional_test.py
+++ b/tests/pipeline_with_optional_test.py
@@ -160,7 +160,9 @@ def test_presence_of_optional_does_not_affect_related_exception() -> None:
 
 
 def test_optional_dependency_in_node_depending_on_param_table() -> None:
-    def use_optional(x: float, y: Optional[int]) -> str:
+    Int = NewType('Int', int)
+
+    def use_optional(x: float, y: Optional[Int]) -> str:
         return f'{x} {y or 123}'
 
     pl = sl.Pipeline([use_optional])
@@ -168,7 +170,7 @@ def test_optional_dependency_in_node_depending_on_param_table() -> None:
     assert pl.compute(sl.Series[int, str]) == sl.Series(
         int, {0: '1.0 123', 1: '2.0 123', 2: '3.0 123'}
     )
-    pl[int] = 11
+    pl[Int] = 11
     assert pl.compute(sl.Series[int, str]) == sl.Series(
         int, {0: '1.0 11', 1: '2.0 11', 2: '3.0 11'}
     )


### PR DESCRIPTION
Fixes #58.

Also fixes #105. We support replacing tables, but each table is treated atomically, i.e., we do not support replacing a column in an existing table when adding another table.