### PR TITLE
fix: separate series subgraphs by index name

### DIFF
--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -78,7 +78,11 @@ def to_graphviz(
 
 def _to_subgraphs(graph: FormattedGraph) -> Dict[str, FormattedGraph]:
     def get_subgraph_name(name: str) -> str:
-        return name.split('[')[0]
+        sgname = name.split('[')[0]
+        if sgname == 'Series':
+            # Example: Series[RowId, Material[Country]] -> RowId, Material[Country]
+            return name.partition('[')[-1].rpartition(']')[0]
+        return sgname
 
     subgraphs: Dict[str, FormattedGraph] = {}
     for p, (p_name, args, ret) in graph.items():


### PR DESCRIPTION
Fixes #104 
Here's how the graph looks after the change:

![Screenshot from 2024-01-29 13-06-04](https://github.com/scipp/sciline/assets/20954731/64442776-54df-4f2f-89b6-ca5e96f845d5)

I'm still a bit unsure what the correct behavior is here.
When should two `Series[ ... ]` nodes be collected in a subgraph?
Is it when *all* types inside `[ ... ]` are the same?