### PR TITLE
Add TaskGraph.keys

### DIFF
--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -860,7 +860,7 @@ class Pipeline:
         else:
             graph = self.build(keys, handler=handler)  # type: ignore[arg-type]
         return TaskGraph(
-            graph=graph, keys=keys, scheduler=scheduler  # type: ignore[arg-type]
+            graph=graph, targets=keys, scheduler=scheduler  # type: ignore[arg-type]
         )
 
     @overload

--- a/src/sciline/task_graph.py
+++ b/src/sciline/task_graph.py
@@ -70,11 +70,11 @@ class TaskGraph:
         self,
         *,
         graph: Graph,
-        keys: Union[type, Tuple[type, ...], Item[T], Tuple[Item[T], ...]],
+        targets: Union[type, Tuple[type, ...], Item[T], Tuple[Item[T], ...]],
         scheduler: Optional[Scheduler] = None,
     ) -> None:
         self._graph = graph
-        self._keys = keys
+        self._keys = targets
         if scheduler is None:
             try:
                 scheduler = DaskScheduler()
@@ -84,7 +84,7 @@ class TaskGraph:
 
     def compute(
         self,
-        keys: Optional[
+        targets: Optional[
             Union[type, Tuple[type, ...], Item[T], Tuple[Item[T], ...]]
         ] = None,
     ) -> Any:
@@ -93,28 +93,28 @@ class TaskGraph:
 
         Parameters
         ----------
-        keys:
+        targets:
             Optional list of keys to compute. This can be used to override the keys
             stored in the graph instance. Note that the keys must be present in the
             graph as intermediate results, otherwise KeyError is raised.
 
         Returns
         -------
-        If ``keys`` is a single type, returns the single result that was computed.
-        If ``keys`` is a tuple of types, returns a dictionary with type as keys
+        If ``targets`` is a single type, returns the single result that was computed.
+        If ``targets`` is a tuple of types, returns a dictionary with type as keys
         and the corresponding results as values.
-
         """
-        if keys is None:
-            keys = self._keys
-        if isinstance(keys, tuple):
-            results = self._scheduler.get(self._graph, list(keys))
-            return dict(zip(keys, results))
+        if targets is None:
+            targets = self._keys
+        if isinstance(targets, tuple):
+            results = self._scheduler.get(self._graph, list(targets))
+            return dict(zip(targets, results))
         else:
-            return self._scheduler.get(self._graph, [keys])[0]
+            return self._scheduler.get(self._graph, [targets])[0]
 
     def keys(self) -> Generator[Key, None, None]:
-        """Iterate over all keys of the graph.
+        """
+        Iterate over all keys of the graph.
 
         Yields all keys, i.e., the types of values that can be computed or are
         provided as parameters.

--- a/src/sciline/task_graph.py
+++ b/src/sciline/task_graph.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from html import escape
-from typing import Any, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, Generator, Optional, Sequence, Tuple, TypeVar, Union
 
 from .scheduler import DaskScheduler, NaiveScheduler, Scheduler
-from .typing import Graph, Item
+from .typing import Graph, Item, Key
 from .utils import keyname
 
 T = TypeVar("T")
@@ -112,6 +112,19 @@ class TaskGraph:
             return dict(zip(keys, results))
         else:
             return self._scheduler.get(self._graph, [keys])[0]
+
+    def keys(self) -> Generator[Key, None, None]:
+        """Iterate over all keys of the graph.
+
+        Yields all keys, i.e., the types of values that can be computed or are
+        provided as parameters.
+
+        Returns
+        -------
+        :
+            Iterable over keys.
+        """
+        yield from self._graph.keys()
 
     def visualize(
         self, **kwargs: Any

--- a/tests/task_graph_test.py
+++ b/tests/task_graph_test.py
@@ -36,37 +36,40 @@ def make_task_graph() -> Graph:
 
 def test_default_scheduler_is_dask_when_dask_available() -> None:
     _ = pytest.importorskip("dask")
-    tg = TaskGraph(graph={}, keys=())
+    tg = TaskGraph(graph={}, targets=())
     assert isinstance(tg._scheduler, sl.scheduler.DaskScheduler)
 
 
 def test_compute_returns_value_when_initialized_with_single_key() -> None:
     graph = make_task_graph()
-    tg = TaskGraph(graph=graph, keys=float)
+    tg = TaskGraph(graph=graph, targets=float)
     assert tg.compute() == 0.5
 
 
 def test_compute_returns_dict_when_initialized_with_key_tuple() -> None:
     graph = make_task_graph()
-    assert TaskGraph(graph=graph, keys=(float,)).compute() == {float: 0.5}
-    assert TaskGraph(graph=graph, keys=(float, int)).compute() == {float: 0.5, int: 1}
+    assert TaskGraph(graph=graph, targets=(float,)).compute() == {float: 0.5}
+    assert TaskGraph(graph=graph, targets=(float, int)).compute() == {
+        float: 0.5,
+        int: 1,
+    }
 
 
 def test_compute_returns_value_when_provided_with_single_key() -> None:
     graph = make_task_graph()
-    tg = TaskGraph(graph=graph, keys=float)
+    tg = TaskGraph(graph=graph, targets=float)
     assert tg.compute(int) == 1
 
 
 def test_compute_returns_dict_when_provided_with_key_tuple() -> None:
     graph = make_task_graph()
-    tg = TaskGraph(graph=graph, keys=float)
+    tg = TaskGraph(graph=graph, targets=float)
     assert tg.compute((int, float)) == {int: 1, float: 0.5}
 
 
 def test_compute_raises_when_provided_with_key_not_in_graph() -> None:
     graph = make_task_graph()
-    tg = TaskGraph(graph=graph, keys=float)
+    tg = TaskGraph(graph=graph, targets=float)
     with pytest.raises(KeyError):
         tg.compute(str)
     with pytest.raises(KeyError):


### PR DESCRIPTION
Needed by https://github.com/scipp/essreflectometry/issues/6

I went with `TaskGraph.keys` instead of `TaskGraph.nodes` in order to avoid the discussion of whether data and provider nodes are conceptually separate or the same node, see #124.