### PR TITLE
Fix blue cluster boxes in task graph visualization

### DIFF
--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -87,7 +87,7 @@ def _to_subgraphs(graph: FormattedGraph) -> Dict[str, FormattedGraph]:
         if kind == 'series':
             # Example: Series[RowId, Material[Country]] -> RowId, Material[Country]
             return name.partition('[')[-1].rpartition(']')[0]
-        return name
+        return name.split('[')[0]
 
     subgraphs: Dict[str, FormattedGraph] = {}
     for p, formatted_p in graph.items():


### PR DESCRIPTION
Make sure we still have clusters in the visualization when using generics.

Fixes #151 