### PR TITLE
Implement ADR 0002 (remove special handling of Optional and Union)

### DIFF
--- a/src/sciline/_provider.py
+++ b/src/sciline/_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
+from types import UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -261,6 +262,8 @@ def _bind_free_typevars(tp: Union[TypeVar, Key], bound: dict[TypeVar, Key]) -> K
             raise UnboundTypeVar(f'Unbound type variable {tp}')
         return result
     elif (origin := get_origin(tp)) is not None:
+        if origin is UnionType:
+            return tp
         result = origin[tuple(_bind_free_typevars(arg, bound) for arg in get_args(tp))]
         if result is None:
             raise ValueError(f'Binding type variables in {tp} resulted in `None`')

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from itertools import chain
+from types import UnionType
 from typing import (
     Any,
     Callable,
@@ -722,11 +723,11 @@ class Pipeline:
         ...
 
     @overload
-    def compute(self, tp: object, **kwargs: Any) -> Any:
+    def compute(self, tp: UnionType, **kwargs: Any) -> Any:
         ...
 
     def compute(
-        self, tp: type | Iterable[type] | Item[T] | object, **kwargs: Any
+        self, tp: type | Iterable[type] | Item[T] | UnionType, **kwargs: Any
     ) -> Any:
         """
         Compute result for the given keys.

--- a/tests/pipeline_with_optional_test.py
+++ b/tests/pipeline_with_optional_test.py
@@ -1,77 +1,70 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from typing import NewType, Optional, Union
+from typing import Optional, Union
 
 import pytest
 
 import sciline as sl
 
 
-def test_provider_returning_optional_disallowed() -> None:
+def test_provider_returning_optional_allowed() -> None:
     def make_optional() -> Optional[int]:
         return 3
 
-    with pytest.raises(ValueError):
-        sl.Pipeline([make_optional])
+    pl = sl.Pipeline([make_optional])
+    assert pl.compute(Optional[int]) == 3
 
 
-def test_provider_returning_union_disallowed() -> None:
+def test_provider_returning_union_allowed() -> None:
     def make_union() -> Union[int, float]:
         return 3
 
-    with pytest.raises(ValueError):
-        sl.Pipeline([make_union])
+    pl = sl.Pipeline([make_union])
+    assert pl.compute(Union[int, float]) == 3
 
 
-def test_parameter_type_union_or_optional_disallowed() -> None:
+def test_parameter_type_union_or_optional_allowed() -> None:
     pipeline = sl.Pipeline()
-    with pytest.raises(ValueError):
-        pipeline[Union[int, float]] = 3  # type: ignore[index]
-    with pytest.raises(ValueError):
-        pipeline[Optional[int]] = 3  # type: ignore[index]
+    pipeline[Union[int, float]] = 3  # type: ignore[index]
+    assert pipeline.compute(Union[int, float]) == 3
+    pipeline[Optional[int]] = 4  # type: ignore[index]
+    assert pipeline.compute(Optional[int]) == 4
 
 
-def test_union_requirement_satisfied_by_unique_match() -> None:
+def test_union_requirement_not_satisfied_by_any_of_its_arguments() -> None:
     def require_union(x: Union[int, float]) -> str:
         return f'{x}'
 
     pipeline = sl.Pipeline([require_union])
     pipeline[int] = 1
-    assert pipeline.compute(str) == '1'
-
-
-def test_union_requirement_with_multiple_matches_raises_AmbiguousProvider() -> None:
-    def require_union(x: Union[int, float]) -> str:
-        return f'{x}'
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
 
     pipeline = sl.Pipeline([require_union])
-    pipeline[int] = 1
-    pipeline[float] = 1.5
-    with pytest.raises(sl.AmbiguousProvider):
-        pipeline.compute(str)
+    pipeline[float] = 1.2
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
 
 
-def test_optional_dependency_can_be_filled_by_non_optional_param(
-    scheduler: sl.scheduler.Scheduler,
-) -> None:
+def test_optional_dependency_cannot_be_filled_by_non_optional_param() -> None:
     def use_optional(x: Optional[int]) -> str:
         return f'{x or 123}'
 
     pipeline = sl.Pipeline([use_optional], params={int: 1})
-    assert pipeline.compute(str, scheduler=scheduler) == '1'
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
 
 
-def test_optional_dependency_can_be_filled_by_non_optional_param_kwarg(
-    scheduler: sl.scheduler.Scheduler,
-) -> None:
+def test_optional_dependency_cannot_be_filled_by_non_optional_param_kwarg() -> None:
     def use_optional(*, x: Optional[int]) -> str:
         return f'{x or 123}'
 
     pipeline = sl.Pipeline([use_optional], params={int: 1})
-    assert pipeline.compute(str, scheduler=scheduler) == '1'
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
 
 
-def test_union_with_none_can_be_used_instead_of_Optional() -> None:
+def test_Union_and_optional_are_distinct() -> None:
     def use_union1(x: Union[int, None]) -> str:
         return f'{x or 123}'
 
@@ -79,17 +72,14 @@ def test_union_with_none_can_be_used_instead_of_Optional() -> None:
         return f'{x or 123}'
 
     pipeline = sl.Pipeline([use_union1], params={int: 1})
-    assert pipeline.compute(str) == '1'
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
     pipeline = sl.Pipeline([use_union2], params={int: 1})
-    assert pipeline.compute(str) == '1'
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
 
 
-def test_optional_requested_directly_can_be_filled_by_non_optional_param() -> None:
-    pipeline = sl.Pipeline([], params={int: 1})
-    assert pipeline.compute(Optional[int]) == 1  # type: ignore[call-overload]
-
-
-def test_optional_dependency_can_be_filled_transitively() -> None:
+def test_optional_dependency_cannot_be_filled_transitively() -> None:
     def use_optional(x: Optional[int]) -> str:
         return f'{x or 123}'
 
@@ -97,133 +87,14 @@ def test_optional_dependency_can_be_filled_transitively() -> None:
         return int(x)
 
     pipeline = sl.Pipeline([use_optional, make_int], params={float: 2.2})
-    assert pipeline.compute(str) == '2'
+    with pytest.raises(sl.UnsatisfiedRequirement):
+        pipeline.get(str)
 
 
-def test_optional_dependency_is_set_to_none_if_no_provider_found(
-    scheduler: sl.scheduler.Scheduler,
-) -> None:
+def test_optional_dependency_can_be_set_to_None() -> None:
     def use_optional(x: Optional[int]) -> str:
         return f'{x or 123}'
 
     pipeline = sl.Pipeline([use_optional])
-    assert pipeline.compute(str, scheduler=scheduler) == '123'
-
-
-def test_optional_dependency_is_set_to_none_if_no_provider_found_kwarg(
-    scheduler: sl.scheduler.Scheduler,
-) -> None:
-    def use_optional(*, x: Optional[int]) -> str:
-        return f'{x or 123}'
-
-    pipeline = sl.Pipeline([use_optional])
-    assert pipeline.compute(str, scheduler=scheduler) == '123'
-
-
-def test_optional_dependency_is_set_to_none_if_no_provider_found_transitively() -> None:
-    def use_optional(x: Optional[int]) -> str:
-        return f'{x or 123}'
-
-    def make_int(x: float) -> int:
-        return int(x)
-
-    pipeline = sl.Pipeline([use_optional, make_int])
+    pipeline[Optional[int]] = None  # type: ignore[index]
     assert pipeline.compute(str) == '123'
-
-
-def test_can_have_both_optional_and_non_optional_path_to_param() -> None:
-    Str1 = NewType('Str1', str)
-    Str2 = NewType('Str2', str)
-    Str12 = NewType('Str12', str)
-    Str21 = NewType('Str21', str)
-
-    def use_optional_int(x: Optional[int]) -> Str1:
-        return Str1(f'{x or 123}')
-
-    def use_int(x: int) -> Str2:
-        return Str2(f'{x}')
-
-    def combine12(x: Str1, y: Str2) -> Str12:
-        return Str12(f'{x} {y}')
-
-    def combine21(x: Str2, y: Str1) -> Str21:
-        return Str21(f'{x} {y}')
-
-    pipeline = sl.Pipeline(
-        [use_optional_int, use_int, combine12, combine21], params={int: 1}
-    )
-    assert pipeline.compute(Str12) == '1 1'
-    assert pipeline.compute(Str21) == '1 1'
-
-
-def test_presence_of_optional_does_not_affect_related_exception() -> None:
-    Str1 = NewType('Str1', str)
-    Str2 = NewType('Str2', str)
-    Str12 = NewType('Str12', str)
-    Str21 = NewType('Str21', str)
-
-    def use_optional_int(x: Optional[int]) -> Str1:
-        return Str1(f'{x or 123}')
-
-    # Make sure the implementation does not unintentionally put "None" here,
-    # triggered by the presence of the optional dependency on int in another provider.
-    def use_int(x: int) -> Str2:
-        return Str2(f'{x}')
-
-    def combine12(x: Str1, y: Str2) -> Str12:
-        return Str12(f'{x} {y}')
-
-    def combine21(x: Str2, y: Str1) -> Str21:
-        return Str21(f'{x} {y}')
-
-    pipeline = sl.Pipeline([use_optional_int, use_int, combine12, combine21])
-    with pytest.raises(sl.UnsatisfiedRequirement):
-        pipeline.compute(Str12)
-    with pytest.raises(sl.UnsatisfiedRequirement):
-        pipeline.compute(Str21)
-
-
-def test_optional_dependency_in_node_depending_on_param_table() -> None:
-    Int = NewType('Int', int)
-
-    def use_optional(x: float, y: Optional[Int]) -> str:
-        return f'{x} {y or 123}'
-
-    pl = sl.Pipeline([use_optional])
-    pl.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
-    assert pl.compute(sl.Series[int, str]) == sl.Series(
-        int, {0: '1.0 123', 1: '2.0 123', 2: '3.0 123'}
-    )
-    pl[Int] = 11
-    assert pl.compute(sl.Series[int, str]) == sl.Series(
-        int, {0: '1.0 11', 1: '2.0 11', 2: '3.0 11'}
-    )
-
-
-def test_optional_dependency_can_be_filled_from_param_table() -> None:
-    def use_optional(x: Optional[float]) -> str:
-        return f'{x or 4.0}'
-
-    pl = sl.Pipeline([use_optional])
-    pl.set_param_table(sl.ParamTable(int, {float: [1.0, 2.0, 3.0]}))
-    assert pl.compute(sl.Series[int, str]) == sl.Series(
-        int, {0: '1.0', 1: '2.0', 2: '3.0'}
-    )
-
-
-def test_optional_without_anchoring_param_raises_when_requesting_series() -> None:
-    Param = NewType('Param', float)
-
-    def use_optional(x: Optional[float]) -> str:
-        return f'{x or 4.0}'
-
-    pl = sl.Pipeline([use_optional])
-    pl.set_param_table(sl.ParamTable(int, {Param: [1.0, 2.0, 3.0]}))
-    # It is a bit ambiguous what we would expect here: Above, we have another param
-    # used from the table, defining the length of the series. Here, we could replicate
-    # the output of use_optional(None) based on the `int` param table:
-    #    sl.Series(int, {0: '4.0', 1: '4.0', 2: '4.0'})
-    # However, we are not supporting this for non-optional dependencies either since
-    # it is unclear whether that would bring conceptual issues or risk.
-    with pytest.raises(sl.UnsatisfiedRequirement):
-        pl.compute(sl.Series[int, str])

--- a/tests/pipeline_with_optional_test.py
+++ b/tests/pipeline_with_optional_test.py
@@ -64,17 +64,27 @@ def test_optional_dependency_cannot_be_filled_by_non_optional_param_kwarg() -> N
         pipeline.get(str)
 
 
-def test_Union_and_optional_are_distinct() -> None:
+def test_Optional_T_is_same_as_Union_T_comma_None() -> None:
     def use_union1(x: Union[int, None]) -> str:
         return f'{x or 123}'
 
     def use_union2(x: Union[None, int]) -> str:
         return f'{x or 123}'
 
-    pipeline = sl.Pipeline([use_union1], params={int: 1})
+    pipeline = sl.Pipeline([use_union1], params={Optional[int]: 1})
+    assert pipeline.compute(str) == '1'
+    pipeline = sl.Pipeline([use_union2], params={Optional[int]: 1})
     with pytest.raises(sl.UnsatisfiedRequirement):
         pipeline.get(str)
-    pipeline = sl.Pipeline([use_union2], params={int: 1})
+
+
+def test_Union_argument_order_matters() -> None:
+    def use_union(x: Union[int, float]) -> str:
+        return f'{x}'
+
+    pipeline = sl.Pipeline([use_union], params={Union[int, float]: 1})
+    assert pipeline.compute(str) == '1'
+    pipeline = sl.Pipeline([use_union], params={Union[float, int]: 1})
     with pytest.raises(sl.UnsatisfiedRequirement):
         pipeline.get(str)
 

--- a/tests/pipeline_with_optional_test.py
+++ b/tests/pipeline_with_optional_test.py
@@ -8,27 +8,27 @@ import sciline as sl
 
 
 def test_provider_returning_optional_allowed() -> None:
-    def make_optional() -> Optional[int]:
+    def make_optional() -> int | None:
         return 3
 
     pl = sl.Pipeline([make_optional])
-    assert pl.compute(Optional[int]) == 3
+    assert pl.compute(int | None) == 3
 
 
 def test_provider_returning_union_allowed() -> None:
-    def make_union() -> Union[int, float]:
+    def make_union() -> int | float:
         return 3
 
     pl = sl.Pipeline([make_union])
-    assert pl.compute(Union[int, float]) == 3
+    assert pl.compute(int | float) == 3
 
 
 def test_parameter_type_union_or_optional_allowed() -> None:
     pipeline = sl.Pipeline()
-    pipeline[Union[int, float]] = 3  # type: ignore[index]
-    assert pipeline.compute(Union[int, float]) == 3
-    pipeline[Optional[int]] = 4  # type: ignore[index]
-    assert pipeline.compute(Optional[int]) == 4
+    pipeline[int | float] = 3  # type: ignore[index]
+    assert pipeline.compute(int | float) == 3
+    pipeline[int | None] = 4  # type: ignore[index]
+    assert pipeline.compute(int | None) == 4
 
 
 def test_union_requirement_not_satisfied_by_any_of_its_arguments() -> None:
@@ -64,27 +64,15 @@ def test_optional_dependency_cannot_be_filled_by_non_optional_param_kwarg() -> N
         pipeline.get(str)
 
 
-def test_Optional_T_is_same_as_Union_T_comma_None() -> None:
-    def use_union1(x: Union[int, None]) -> str:
-        return f'{x or 123}'
-
-    def use_union2(x: Union[None, int]) -> str:
-        return f'{x or 123}'
-
-    pipeline = sl.Pipeline([use_union1], params={Optional[int]: 1})
-    assert pipeline.compute(str) == '1'
-    pipeline = sl.Pipeline([use_union2], params={Optional[int]: 1})
-    with pytest.raises(sl.UnsatisfiedRequirement):
-        pipeline.get(str)
-
-
 def test_Union_argument_order_matters() -> None:
-    def use_union(x: Union[int, float]) -> str:
+    def use_union(x: int | float) -> str:
         return f'{x}'
 
-    pipeline = sl.Pipeline([use_union], params={Union[int, float]: 1})
+    pipeline = sl.Pipeline([use_union])
+    pipeline[int | float] = 1  # type: ignore[index]
     assert pipeline.compute(str) == '1'
-    pipeline = sl.Pipeline([use_union], params={Union[float, int]: 1})
+    pipeline = sl.Pipeline([use_union])
+    pipeline[float | int] = 1  # type: ignore[index]
     with pytest.raises(sl.UnsatisfiedRequirement):
         pipeline.get(str)
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -102,7 +102,7 @@ def test_key_full_qualname_new_type() -> None:
     # The __qualname__ of NewTypes is the same as __name__, the result is therefore
     # missing test_key_full_qualname_new_type.<locals>
     MyType = NewType('MyType', str)
-    assert _utils.key_full_qualname(MyType) == 'utils_test.MyType'
+    assert _utils.key_full_qualname(MyType) == 'tests.utils_test.MyType'
 
 
 @pytest.mark.skipif(sys.version_info < (3, 12), reason="requires python3.12 or higher")
@@ -110,7 +110,7 @@ def test_key_full_qualname_type_alias_type() -> None:
     # Use exec to avoid a syntax error in older python
     code = """
 type MyType = float
-assert _utils.key_full_qualname(MyType) == 'utils_test.MyType'
+assert _utils.key_full_qualname(MyType) == 'tests.utils_test.MyType'
     """
     exec(code)
 
@@ -120,7 +120,7 @@ def test_key_full_qualname_generic_type_alias_type() -> None:
     # Use exec to avoid a syntax error in older python
     code = """
 type MyType[T] = dict[str, T]
-assert _utils.key_full_qualname(MyType[int]) == 'utils_test.MyType[builtins.int]'
+assert _utils.key_full_qualname(MyType[int]) == 'tests.utils_test.MyType[builtins.int]'
     """
     exec(code)
 
@@ -130,7 +130,7 @@ def test_key_full_qualname_type_var() -> None:
     # test_key_full_qualname_type_var.<locals>
     MyType = TypeVar('MyType')
     res = _utils.key_full_qualname(MyType)  # type: ignore[arg-type]
-    assert res == 'utils_test.~MyType'
+    assert res == 'tests.utils_test.~MyType'
 
 
 def test_key_full_qualname_item() -> None:
@@ -146,10 +146,13 @@ def test_key_full_qualname_builtin_generic() -> None:
     MyType = NewType('MyType', str)
     assert _utils.key_full_qualname(list) == 'builtins.list'
     assert _utils.key_full_qualname(list[float]) == 'builtins.list[builtins.float]'
-    assert _utils.key_full_qualname(list[MyType]) == 'builtins.list[utils_test.MyType]'
+    assert (
+        _utils.key_full_qualname(list[MyType])
+        == 'builtins.list[tests.utils_test.MyType]'
+    )
     assert (
         _utils.key_full_qualname(dict[str, MyType])
-        == 'builtins.dict[builtins.str, utils_test.MyType]'
+        == 'builtins.dict[builtins.str, tests.utils_test.MyType]'
     )
 
 
@@ -163,16 +166,16 @@ def test_key_full_qualname_custom_generic() -> None:
 
     assert (
         _utils.key_full_qualname(G)
-        == 'utils_test.test_key_full_qualname_custom_generic.<locals>.G'
+        == 'tests.utils_test.test_key_full_qualname_custom_generic.<locals>.G'
     )
     assert (
         _utils.key_full_qualname(G[int])
-        == 'utils_test.test_key_full_qualname_custom_generic.<locals>.G[builtins.int]'
+        == 'tests.utils_test.test_key_full_qualname_custom_generic.<locals>.G[builtins.int]'  # noqa E501
     )
     assert (
         _utils.key_full_qualname(G[MyType])
-        == 'utils_test.test_key_full_qualname_custom_generic.'
-        '<locals>.G[utils_test.MyType]'
+        == 'tests.utils_test.test_key_full_qualname_custom_generic.'
+        '<locals>.G[tests.utils_test.MyType]'
     )
 
 
@@ -187,17 +190,17 @@ def test_key_full_qualname_custom_generic_two_params() -> None:
 
     assert (
         _utils.key_full_qualname(G)
-        == 'utils_test.test_key_full_qualname_custom_generic_two_params.<locals>.G'
+        == 'tests.utils_test.test_key_full_qualname_custom_generic_two_params.<locals>.G'  # noqa E501
     )
     assert (
         _utils.key_full_qualname(G[int, tuple[float]])
-        == 'utils_test.test_key_full_qualname_custom_generic_two_params.'
+        == 'tests.utils_test.test_key_full_qualname_custom_generic_two_params.'
         '<locals>.G[builtins.int, builtins.tuple[builtins.float]]'
     )
     assert (
         _utils.key_full_qualname(G[list[MyType], MyType])
-        == 'utils_test.test_key_full_qualname_custom_generic_two_params.<locals>.'
-        'G[builtins.list[utils_test.MyType], utils_test.MyType]'
+        == 'tests.utils_test.test_key_full_qualname_custom_generic_two_params.<locals>.'
+        'G[builtins.list[tests.utils_test.MyType], tests.utils_test.MyType]'
     )
 
 
@@ -221,11 +224,11 @@ def test_provider_full_qualname_function() -> None:
 
     assert (
         _utils.provider_full_qualname(Provider.from_function(foo))
-        == 'utils_test.test_provider_full_qualname_function.<locals>.foo'
+        == 'tests.utils_test.test_provider_full_qualname_function.<locals>.foo'
     )
     assert (
         _utils.provider_full_qualname(Provider.from_function(module_foo))
-        == 'utils_test.module_foo'
+        == 'tests.utils_test.module_foo'
     )
 
 


### PR DESCRIPTION
While `Pipeline` will be re-implemented, I nevertheless made this change, since it allows for updating units tests with new expected behavior, which will make the re-implementation easier/smaller (will pass the same unit tests), decoupling the behavior change from the re-implementation.