### PR TITLE
Expose and rename properties for accessing underlying graphs and indices

### DIFF
--- a/src/sciline/data_graph.py
+++ b/src/sciline/data_graph.py
@@ -9,6 +9,7 @@ from typing import Any, TypeVar, get_args
 
 import cyclebane as cb
 import networkx as nx
+from cyclebane.node_values import IndexName, IndexValue
 
 from ._provider import ArgSpec, Provider, ToProvider, _bind_free_typevars
 from .handler import ErrorHandler, HandleAsBuildTimeException
@@ -66,12 +67,12 @@ class DataGraph:
         return self.copy()
 
     @property
-    def index_names(self) -> tuple[cb.graph.IndexName, ...]:
+    def index_names(self) -> tuple[IndexName, ...]:
         """Names of the indices (dimensions) of the graph."""
         return self._cbgraph.index_names
 
     @property
-    def indices(self) -> dict[cb.graph.IndexName, Iterable[cb.graph.IndexValue]]:
+    def indices(self) -> dict[IndexName, Iterable[IndexValue]]:
         """Names and values of the indices of the graph."""
         return self._cbgraph.indices
 

--- a/src/sciline/data_graph.py
+++ b/src/sciline/data_graph.py
@@ -66,21 +66,39 @@ class DataGraph:
         return self.copy()
 
     @property
-    def _graph(self) -> nx.DiGraph:
+    def index_names(self) -> tuple[cb.graph.IndexName, ...]:
+        """Names of the indices (dimensions) of the graph."""
+        return self._cbgraph.index_names
+
+    @property
+    def indices(self) -> dict[cb.graph.IndexName, Iterable[cb.graph.IndexValue]]:
+        """Names and values of the indices of the graph."""
+        return self._cbgraph.indices
+
+    @property
+    def cyclebane_graph(self) -> cb.Graph:
+        """The underlying Cyclebane graph."""
+        return self._cbgraph
+
+    @property
+    def networkx_graph(self) -> nx.DiGraph:
+        """The underlying NetworkX graph held by :py:func:`cyclebane_graph`."""
         return self._cbgraph.graph
 
     def _get_clean_node(self, key: Key) -> Any:
         """Return node ready for setting value or provider."""
         if key is NoneType:
             raise ValueError('Key must not be None')
-        if key in self._graph:
-            self._graph.remove_edges_from(list(self._graph.in_edges(key)))
-            self._graph.nodes[key].pop('value', None)
-            self._graph.nodes[key].pop('provider', None)
-            self._graph.nodes[key].pop('reduce', None)
+        if key in self.networkx_graph:
+            self.networkx_graph.remove_edges_from(
+                list(self.networkx_graph.in_edges(key))
+            )
+            self.networkx_graph.nodes[key].pop('value', None)
+            self.networkx_graph.nodes[key].pop('provider', None)
+            self.networkx_graph.nodes[key].pop('reduce', None)
         else:
-            self._graph.add_node(key)
-        return self._graph.nodes[key]
+            self.networkx_graph.add_node(key)
+        return self.networkx_graph.nodes[key]
 
     def insert(self, provider: ToProvider | Provider, /) -> None:
         """
@@ -104,7 +122,7 @@ class DataGraph:
         provider = provider.bind_type_vars({})
         self._get_clean_node(return_type)['provider'] = provider
         for dep in provider.arg_spec.keys():
-            self._graph.add_edge(dep, return_type, key=dep)
+            self.networkx_graph.add_edge(dep, return_type, key=dep)
 
     def __setitem__(self, key: Key, value: DataGraph | Any) -> None:
         """
@@ -152,13 +170,13 @@ class DataGraph:
         import graphviz
 
         dot = graphviz.Digraph(strict=True, **kwargs)
-        for node in self._graph.nodes:
+        for node in self.networkx_graph.nodes:
             dot.node(str(node), label=str(node), shape='box')
-            attrs = self._graph.nodes[node]
+            attrs = self.networkx_graph.nodes[node]
             attrs = '\n'.join(f'{k}={v}' for k, v in attrs.items())
             dot.node(str(node), label=f'{node}\n{attrs}', shape='box')
-        for edge in self._graph.edges:
-            key = self._graph.edges[edge].get('key')
+        for edge in self.networkx_graph.edges:
+            key = self.networkx_graph.edges[edge].get('key')
             label = str(key) if key is not None else ''
             dot.edge(str(edge[0]), str(edge[1]), label=label)
         return dot

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -197,7 +197,7 @@ class Pipeline(DataGraph):
         return results
 
     def _repr_html_(self) -> str:
-        nodes = ((key, data) for key, data in self.networkx_graph.nodes.items())
+        nodes = ((key, data) for key, data in self.underlying_graph.nodes.items())
         return pipeline_html_repr(nodes)
 
 
@@ -235,7 +235,7 @@ def get_mapped_node_names(
 
     candidates = [
         node
-        for node in graph.networkx_graph.nodes
+        for node in graph.underlying_graph.nodes
         if isinstance(node, MappedNode) and node.name == base_name
     ]
     if len(candidates) == 0:

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -197,7 +197,7 @@ class Pipeline(DataGraph):
         return results
 
     def _repr_html_(self) -> str:
-        nodes = ((key, data) for key, data in self._graph.nodes.items())
+        nodes = ((key, data) for key, data in self.networkx_graph.nodes.items())
         return pipeline_html_repr(nodes)
 
 
@@ -235,7 +235,7 @@ def get_mapped_node_names(
 
     candidates = [
         node
-        for node in graph._cbgraph.graph.nodes
+        for node in graph.networkx_graph.nodes
         if isinstance(node, MappedNode) and node.name == base_name
     ]
     if len(candidates) == 0:
@@ -250,7 +250,7 @@ def get_mapped_node_names(
         )
     # Drops unrelated indices
     graph = graph[candidates[0]]  # type: ignore[index]
-    indices = graph._cbgraph.indices
+    indices = graph.indices
     if index_names is not None:
         indices = {name: indices[name] for name in indices if name in index_names}
     index_names = tuple(indices)

--- a/tests/pipeline_map_reduce_test.py
+++ b/tests/pipeline_map_reduce_test.py
@@ -120,7 +120,7 @@ def test_compute_mapped_multiple_indices_creates_multiindex() -> None:
     assert result['b', 'bb'] == C(11)
     assert result['c', 'aa'] == C(20)
     assert result['c', 'bb'] == C(21)
-    assert result.index.names == list(mapped._cbgraph.index_names)
+    assert result.index.names == list(mapped.index_names)
     assert result.name == C
 
 


### PR DESCRIPTION
This will be required for a variety of functionality that we plan to add in Sciline or elsewhere. A simple example is #83:

```python
import networkx as nx
import pandas as pd

g = workflow.networkx_graph
nodes = [node for node in g.nodes() if len(g.in_edges(node)) == 0]
nodes = [node for node in nodes if 'provider' not in g.nodes[node]]

not_set = '(not set)'
df = pd.DataFrame(
    {'node': nodes, 'value': [g.nodes[node].get('value', not_set) for node in nodes]}
)
df
```
I don't know if this (without the Pandas bit) is something that should be added as a helper function in Sciline, or more specifically in our applications, e.g., in ESSreduce?