### PR TITLE
Add Provider.__eq__

### DIFF
--- a/src/sciline/_provider.py
+++ b/src/sciline/_provider.py
@@ -122,6 +122,14 @@ class Provider:
             kind=self._kind,
         )
 
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Provider):
+            return self._func == other._func
+        return NotImplemented
+
+    def __ne__(self, other: object) -> bool:
+        return not (self == other)
+
     def __str__(self) -> str:
         return f"Provider('{self.location.name}')"
 

--- a/src/sciline/_provider.py
+++ b/src/sciline/_provider.py
@@ -25,9 +25,7 @@ if TYPE_CHECKING:
 ToProvider = Callable[..., Any]
 """Callable that can be converted to a provider."""
 
-ProviderKind = Literal[
-    'function', 'parameter', 'series', 'table_cell', 'sentinel', 'unsatisfied'
-]
+ProviderKind = Literal['function', 'parameter', 'unsatisfied']
 """Identifies the kind of a provider, most are used internally."""
 
 
@@ -75,18 +73,6 @@ class Provider:
             kind='parameter',
             location=ProviderLocation(
                 name=f'param({type(param).__name__})', module=_module_name(param)
-            ),
-        )
-
-    @classmethod
-    def table_cell(cls, param: Any) -> Provider:
-        """Construct a provider that returns the label for a table row."""
-        return cls(
-            func=lambda: param,
-            arg_spec=ArgSpec.null(),
-            kind='table_cell',
-            location=ProviderLocation(
-                name=f'table_cell({type(param).__name__})', module=_module_name(param)
             ),
         )
 

--- a/src/sciline/data_graph.py
+++ b/src/sciline/data_graph.py
@@ -128,7 +128,7 @@ class DataGraph:
         ----------
         key:
             Type to provide a value for.
-        param:
+        value:
             Concrete value to provide.
         """
         # This is a questionable approach: Using MyGeneric[T] as a key will actually

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -74,15 +74,9 @@ def to_graphviz(
 
 
 def _to_subgraphs(graph: FormattedGraph) -> dict[str, FormattedGraph]:
-    def get_subgraph_name(name: str, kind: str) -> str:
-        if kind == 'series':
-            # Example: Series[RowId, Material[Country]] -> RowId, Material[Country]
-            return name.partition('[')[-1].rpartition(']')[0]
-        return name.split('[')[0]
-
     subgraphs: dict[str, FormattedGraph] = {}
     for p, formatted_p in graph.items():
-        subgraph_name = get_subgraph_name(formatted_p.ret.name, formatted_p.kind)
+        subgraph_name = formatted_p.ret.name.split('[')[0]
         subgraphs.setdefault(subgraph_name, {})
         subgraphs[subgraph_name][p] = formatted_p
     return subgraphs
@@ -105,12 +99,7 @@ def _add_subgraph(graph: FormattedGraph, dot: Digraph, subgraph: Digraph) -> Non
                 formatted_p.ret.name,
                 shape='box3d' if formatted_p.ret.collapsed else 'rectangle',
             )
-        # Do not draw the internal provider gathering index-dependent results into
-        # a dict
-        if formatted_p.kind == 'series':
-            for arg in formatted_p.args:
-                dot.edge(arg.name, formatted_p.ret.name, style='dashed')
-        elif formatted_p.kind == 'function':
+        if formatted_p.kind == 'function':
             dot.node(p, formatted_p.name, shape='ellipse')
             for arg in formatted_p.args:
                 dot.edge(arg.name, p)


### PR DESCRIPTION
Fixes #176

I am not 100% confident that checking the function is enough because `arg_spec` gets overwritten when generic providers are specialised. However, I did not manage to find a case where this lead to a wrong result in `Pipeline.__setitem__`.