### PR TITLE
Add `mode` argument to `visualize` for more compact data or task graph display

### DIFF
--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -139,7 +139,6 @@ class Pipeline(DataGraph):
             cluster_color=cluster_color,
             **kwargs,
         )
-        return self.get(tp, handler=HandleAsComputeTimeException()).visualize(**kwargs)
 
     def get(
         self,

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 from collections.abc import Callable, Hashable, Iterable, Sequence
 from itertools import chain
 from types import UnionType
-from typing import TYPE_CHECKING, Any, TypeVar, get_args, get_type_hints, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    TypeVar,
+    get_args,
+    get_type_hints,
+    overload,
+)
 
 from ._provider import Provider, ToProvider
 from .data_graph import DataGraph, to_task_graph
@@ -89,7 +97,15 @@ class Pipeline(DataGraph):
         """
         return self.get(tp, **kwargs).compute()
 
-    def visualize(self, tp: type | Iterable[type], **kwargs: Any) -> graphviz.Digraph:
+    def visualize(
+        self,
+        tp: type | Iterable[type],
+        compact: bool = False,
+        mode: Literal['data', 'task', 'both'] = 'both',
+        cluster_generics: bool = True,
+        cluster_color: str | None = '#f0f0ff',
+        **kwargs: Any,
+    ) -> graphviz.Digraph:
         """
         Return a graphviz Digraph object representing the graph for the given keys.
 
@@ -100,10 +116,26 @@ class Pipeline(DataGraph):
         tp:
             Type to visualize the graph for.
             Can be a single type or an iterable of types.
+        compact:
+            If True, parameter-table-dependent branches are collapsed into a single copy
+            of the branch. Recommended for large graphs with long parameter tables.
+        mode:
+            If 'data', only data nodes are shown. If 'task', only task nodes and input
+            data nodes are shown. If 'both', all nodes are shown.
+        cluster_generics:
+            If True, generic products are grouped into clusters.
+        cluster_color:
+            Background color of clusters. If None, clusters are dotted.
         kwargs:
             Keyword arguments passed to :py:class:`graphviz.Digraph`.
         """
-        return self.get(tp, handler=HandleAsComputeTimeException()).visualize(**kwargs)
+        return self.get(tp, handler=HandleAsComputeTimeException()).visualize(
+            compact=compact,
+            mode=mode,
+            cluster_generics=cluster_generics,
+            cluster_color=cluster_color,
+            **kwargs,
+        )
 
     def get(
         self,

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -101,7 +101,7 @@ class Pipeline(DataGraph):
         self,
         tp: type | Iterable[type],
         compact: bool = False,
-        mode: Literal['data', 'task', 'both'] = 'both',
+        mode: Literal['data', 'task', 'both'] = 'data',
         cluster_generics: bool = True,
         cluster_color: str | None = '#f0f0ff',
         **kwargs: Any,

--- a/src/sciline/task_graph.py
+++ b/src/sciline/task_graph.py
@@ -129,7 +129,7 @@ class TaskGraph:
     def visualize(
         self,
         compact: bool = False,
-        mode: Literal['data', 'task', 'both'] = 'both',
+        mode: Literal['data', 'task', 'both'] = 'data',
         cluster_generics: bool = True,
         cluster_color: str | None = '#f0f0ff',
         **kwargs: Any,

--- a/src/sciline/task_graph.py
+++ b/src/sciline/task_graph.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator, Hashable, Sequence
 from html import escape
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 
 from ._utils import key_name
 from .scheduler import DaskScheduler, NaiveScheduler, Scheduler
@@ -126,18 +126,42 @@ class TaskGraph:
         """
         yield from self._graph.keys()
 
-    def visualize(self, **kwargs: Any) -> graphviz.Digraph:  # type: ignore[name-defined] # noqa: F821
+    def visualize(
+        self,
+        compact: bool = False,
+        mode: Literal['data', 'task', 'both'] = 'both',
+        cluster_generics: bool = True,
+        cluster_color: str | None = '#f0f0ff',
+        **kwargs: Any,
+    ) -> graphviz.Digraph:  # type: ignore[name-defined] # noqa: F821
         """
         Return a graphviz Digraph object representing the graph.
 
         Parameters
         ----------
+        compact:
+            If True, parameter-table-dependent branches are collapsed into a single copy
+            of the branch. Recommended for large graphs with long parameter tables.
+        mode:
+            If 'data', only data nodes are shown. If 'task', only task nodes and input
+            data nodes are shown. If 'both', all nodes are shown.
+        cluster_generics:
+            If True, generic products are grouped into clusters.
+        cluster_color:
+            Background color of clusters. If None, clusters are dotted.
         kwargs:
             Keyword arguments passed to :py:class:`graphviz.Digraph`.
         """
         from .visualize import to_graphviz
 
-        return to_graphviz(self._graph, **kwargs)
+        return to_graphviz(
+            self._graph,
+            compact=compact,
+            mode=mode,
+            cluster_generics=cluster_generics,
+            cluster_color=cluster_color,
+            **kwargs,
+        )
 
     def serialize(self) -> dict[str, Json]:
         """Serialize the graph to JSON.

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -31,7 +31,7 @@ FormattedGraph = dict[str, FormattedProvider]
 def to_graphviz(
     graph: Graph,
     compact: bool = False,
-    mode: Literal['data', 'task', 'both'] = 'both',
+    mode: Literal['data', 'task', 'both'] = 'data',
     cluster_generics: bool = True,
     cluster_color: str | None = '#f0f0ff',
     **kwargs: Any,
@@ -117,7 +117,7 @@ def _add_subgraph(
     graph: FormattedGraph,
     dot: Digraph,
     subgraph: Digraph,
-    mode: Literal['data', 'task', 'both'] = 'both',
+    mode: Literal['data', 'task', 'both'],
 ) -> None:
     cluster = subgraph.name is not None
     cluster_connected = []

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import html
 from collections.abc import Hashable
 from dataclasses import dataclass
 from typing import Any, Literal, get_args, get_origin
@@ -134,7 +135,8 @@ def _add_subgraph(
             name = f'<{ret_name}>'
         if mode == 'data' and formatted_p.kind == 'function':
             # Show provider name in data mode
-            via = f'<font point-size="11">via:<i>{formatted_p.name}</i></font>'
+            via_name = html.escape(formatted_p.name)
+            via = f'<font point-size="11">via:<i>{via_name}</i></font>'
             if common_provider:
                 origin = ret_name.split('[')[0]
                 subgraph.attr(label=f'<{origin}<br/>{via}>')

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -169,7 +169,13 @@ def _add_subgraph(
                         # Avoid duplicate arrows to subnodes if all providers are the
                         # same and the argument is not a generic
                         if arg.name not in cluster_connected:
-                            dot.edge(arg.name, ret_name, lhead=subgraph.name)
+                            dot.edge(
+                                arg.name,
+                                ret_name,
+                                lhead=subgraph.name,
+                                # Thick pen to indicate multiple connections
+                                penwidth='2.0',
+                            )
                             cluster_connected.append(arg.name)
                     else:
                         dot.edge(arg.name, ret_name)

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -69,7 +69,8 @@ def to_graphviz(
     else:
         dot.graph_attr['ranksep'] = '0.5'
         dot.graph_attr['nodesep'] = '0.1'
-        dot.edge_attr['tailport'] = 's'
+        # With tailport='s' we get more curved edges, so we omit it. In larger graphs
+        # this still seems to happen though, may need revisiting.
         # Nodes are wide in west-east direction, so *not* connecting to headport='n'
         # looks better
     dot.node_attr.update({'height': '0', 'width': '0'})

--- a/src/sciline/visualize.py
+++ b/src/sciline/visualize.py
@@ -76,6 +76,7 @@ def to_graphviz(
     dot.node_attr.update(kwargs.get('node_attr', {}))
     dot.edge_attr.update(kwargs.get('edge_attr', {}))
     dot.graph_attr.update(kwargs.get('graph_attr', {}))
+    # Compound is required for connecting edges to clusters
     dot.graph_attr['compound'] = 'true'
     formatted_graph = _format_graph(graph, compact=compact)
     ordered_graph = dict(
@@ -95,6 +96,8 @@ def to_graphviz(
                     dot_subgraph.attr(style='filled', color=cluster_color)
                 # For keys such as MyType[int] we show MyType only once as the cluster
                 # label. The nodes within the cluster will only show to bit inside [].
+                # This save a lot of horizontal space in the graph in LR mode and
+                # duplication and clutter in general.
                 origin = next(iter(subgraph.values())).ret.name.split('[')[0]
                 dot_subgraph.attr(label=f'{origin}')
             _add_subgraph(subgraph, dot, dot_subgraph, mode=mode)


### PR DESCRIPTION
Here is an before and after for ESSsans' `IofQ[SampleRun]`.
Before:
![sciline-vis-before](https://github.com/user-attachments/assets/8c9ee477-f9f8-42d9-9955-c5498e67e10c)
After:
![sciline-vis-after](https://github.com/user-attachments/assets/15946b46-f126-4060-805c-23fc41819073)

Fixes #82.