### PR TITLE
Add a method for connecting providers to different inputs

### DIFF
--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1688,6 +1688,15 @@ def test_override_input_does_nothing_if_input_does_not_exist() -> None:
     assert new.compute(str) == "7"
 
 
+def test_override_input_preserves_uses_of_override_type() -> None:
+    def foo(x: float) -> str:
+        return str(x)
+
+    original = sl.Pipeline([foo], params={int: 7, float: 4.4})
+    new = original.override_input(int, float)  # keeps float arg of foo
+    assert new.compute(str) == "4.4"
+
+
 # TODO generic -> regular is ambiguous
 # TODO regular -> generic works, duplicates regular
 # TODO multiple type vars


### PR DESCRIPTION
This is only a draft because implementing proper support for generics is non-trivial and I would like to get feedback before doing so. However, even in its current state, this implementation is useful.

This PR proposes a mechanism for replacing the inputs of providers with arbitrary nodes. I initially outlined the idea on Slack after our discussion about workflows on 2025-01-15. `override_inputs` allows side-stepping domain types and telling Sciline to use a different type instead.

## Benefits

### 'Lying' domain types

We have some pipelines where users can switch off operations. E.g., footprint correction in ESSreflectometry. Doing so keeps a `FootprintCorrectedData` node in the graph which is misleading.

Given a provider like
```python
def correct_by_footprint(raw: RawData, footprint: Footprint) -> FootprintCorrectedData:
    ...
```
and using
```python
pl = sciline.Pipeline([correct_by_footprint, ...])
pl = pl.override_input(FootprintCorrectedData, RawData)
```
effectively removes footprint correction from the graph. The resulting pipeline still contains `correct_by_footprint` and `FootprintCorrectedData` but they are no longer ancestors to any other nodes. This means that the correction won't be used by `compute`. And it won't show up in visualisations or when serialising to JSON.

### Choosing alternative algorithms

In powder diffraction, we allow the user to select between normalisation by proton charge and monitor. This can be achieved like so:
1. Create dedicated domain types `ProtonChargeNormalizedRunData` and `HistogramMonitorNormalizedRunData` and use those as return types of normalisation providers.
2. Create a type `NormalizedRunData` and use that as input type for all providers consuming normalised data.
3. Create a pipeline and add all providers for *all* normalisations.
4. Select a normalisation using
```python
pl = pl.override_input(NormalizedRunData, ProtonChargeNormalizedRunData)
```
Any providers that request `NormalizedRunData` will now get `ProtonChargeNormalizedRunData` instead.

I implemented this in [TODO](https://github.com/scipp/essdiffraction/pull/121)

## Downsides

### This is a one time operation.

The providers are not removed. This means that adding providers later can reintroduce the overridden type. This can partially be ameliorated by removing the overridden nodes. Or fixed full by creating an alias instead that affects all providers added later. (A bit like aliases in coord transforms)

### No type safety

We normally benefit from some level of type safety by relying on type hints. This is lost if we allow arbitrary overrides. I don't think this is a major problem given that Dask has no type safety either.

### Complex implementation

Especially for generic types. This may not be worth the effort. But as I showed above, even a simple implementation fixes the most pressing issues.