### PR TITLE
Add progress reporters

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -52,6 +52,7 @@
    :template: module-template.rst
    :recursive:
 
+   reporter
    serialize
    sphinxext
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ test = [
     "numpy",
     "pandas",
 ]
+progress = [
+    "rich",
+]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/scipp/sciline/issues"

--- a/src/sciline/__init__.py
+++ b/src/sciline/__init__.py
@@ -10,7 +10,7 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
 from . import scheduler
-from ._provider import UnboundTypeVar
+from ._provider import UnboundTypeVar, Provider
 from .domain import Scope, ScopeTwoParams
 from .handler import (
     HandleAsBuildTimeException,
@@ -24,6 +24,7 @@ __all__ = [
     "HandleAsBuildTimeException",
     "HandleAsComputeTimeException",
     "Pipeline",
+    "Provider",
     "Scope",
     "ScopeTwoParams",
     'TaskGraph',

--- a/src/sciline/__init__.py
+++ b/src/sciline/__init__.py
@@ -10,7 +10,7 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
 from . import scheduler
-from ._provider import UnboundTypeVar, Provider
+from ._provider import Provider, UnboundTypeVar
 from .domain import Scope, ScopeTwoParams
 from .handler import (
     HandleAsBuildTimeException,

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -20,6 +20,7 @@ from ._utils import key_name
 from .data_graph import DataGraph, to_task_graph
 from .display import pipeline_html_repr
 from .handler import ErrorHandler, HandleAsComputeTimeException, UnsatisfiedRequirement
+from .reporter import Reporter
 from .scheduler import Scheduler
 from .task_graph import TaskGraph
 from .typing import Key
@@ -74,15 +75,26 @@ class Pipeline(DataGraph):
             self[tp] = param
 
     @overload
-    def compute(self, tp: type[T], **kwargs: Any) -> T: ...
+    def compute(
+        self, tp: type[T], reporter: Reporter | None = None, **kwargs: Any
+    ) -> T: ...
 
     @overload
-    def compute(self, tp: Iterable[type[T]], **kwargs: Any) -> dict[type[T], T]: ...
+    def compute(
+        self, tp: Iterable[type[T]], reporter: Reporter | None = None, **kwargs: Any
+    ) -> dict[type[T], T]: ...
 
     @overload
-    def compute(self, tp: UnionType, **kwargs: Any) -> Any: ...
+    def compute(
+        self, tp: UnionType, reporter: Reporter | None = None, **kwargs: Any
+    ) -> Any: ...
 
-    def compute(self, tp: type | Iterable[type] | UnionType, **kwargs: Any) -> Any:
+    def compute(
+        self,
+        tp: type | Iterable[type] | UnionType,
+        reporter: Reporter | None = None,
+        **kwargs: Any,
+    ) -> Any:
         """
         Compute result for the given keys.
 
@@ -93,10 +105,12 @@ class Pipeline(DataGraph):
         tp:
             Type to compute the result for.
             Can be a single type or an iterable of types.
+        reporter:
+            Optional reporter to track progress of this computation.
         kwargs:
             Keyword arguments passed to the ``.get()`` method.
         """
-        return self.get(tp, **kwargs).compute()
+        return self.get(tp, **kwargs).compute(reporter=reporter)
 
     def visualize(
         self,

--- a/src/sciline/reporter.py
+++ b/src/sciline/reporter.py
@@ -279,4 +279,8 @@ class _ProviderList:
             active_providers = rf"\[{', '.join(self._provider_names.values())}]"
         else:
             active_providers = ""
+        # Not overflowing the line seems more defensive when this code is used
+        # in a larger context.
+        options.overflow = 'ellipsis'
+        options.no_wrap = True
         return console.render(active_providers, options)

--- a/src/sciline/reporter.py
+++ b/src/sciline/reporter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+"""Progress reporters for pipelines."""
 
 from __future__ import annotations
 
@@ -14,7 +15,20 @@ from ._utils import provider_name
 
 
 class Reporter(ABC):
-    """Base class for progress reporters of computations."""
+    """Base class for progress reporters of computations.
+
+    A ``Reporter`` instance must not be used for multiple computations concurrently!
+
+    Reporters should be passed to :meth:`sciline.Pipeline.compute`, e.g.:
+
+    .. code-block:: python
+
+         from sciline import Pipeline
+         from sciline.reporter import RichReporter
+         reporter = RichReporter()
+         pipeline = Pipeline(providers)
+         pipeline.compute(Result, reporter=reporter)
+    """
 
     def __init__(self) -> None:
         self._n_steps = 0
@@ -23,7 +37,8 @@ class Reporter(ABC):
     def run_computation(self, providers: Iterable[Provider]) -> Reporter:
         """Run a single computation with progress reporting.
 
-        A ``Reporter`` instance must not be used for multiple computations concurrently!
+        This method is primarily meant for internal use.
+        As a user, you should pass reporters to :meth:`Pipeline.compute`.
 
         Use this method in a ``with`` statement:
 
@@ -101,6 +116,17 @@ class RichReporter(Reporter):
     This class uses the `rich <https://rich.readthedocs.io/en/stable/index.html>`_
     package to display a progress bar.
     Rich is not a hard dependency of Sciline and must be installed separately.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+         from sciline import Pipeline
+         from sciline.reporter import RichReporter
+         reporter = RichReporter()
+         pipeline = Pipeline(providers)
+         pipeline.compute(Result, reporter=reporter)
     """
 
     def __init__(

--- a/src/sciline/reporter.py
+++ b/src/sciline/reporter.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from __future__ import annotations
+
+import functools
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Hashable, Iterable
+from types import TracebackType
+from typing import Any
+
+from ._provider import Provider
+from ._utils import provider_name
+
+
+class Reporter(ABC):
+    """Base class for progress reporters of computations."""
+
+    def __init__(self) -> None:
+        self._n_steps = 0
+        self._provider_id = -1
+
+    def run_computation(self, providers: Iterable[Provider]) -> Reporter:
+        """Run a single computation with progress reporting.
+
+        A ``Reporter`` instance must not be used for multiple computations concurrently!
+
+        Use this method in a ``with`` statement:
+
+        .. code-block:: python
+
+            with reporter.run_computation(providers):
+                # Perform computation
+
+        This method exists mainly to provide arguments when entering a reporting
+        context, implementers should mainly override ``__enter__``.
+        """
+        self._n_steps = sum(1 for provider in providers if provider.kind == "function")
+        return self
+
+    @abstractmethod
+    def __enter__(self) -> None:
+        """Computation is starting."""
+
+    @abstractmethod
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Computation is finished."""
+
+    @abstractmethod
+    def on_provider_start(self, provider: Provider) -> int:
+        """Called when a provider is started."""
+
+    @abstractmethod
+    def on_provider_end(self, provider_id: int) -> None:
+        """Called when a provider has finished."""
+
+    def reporting_provider_func(self, provider: Provider) -> Callable[..., Any]:
+        """Wrap a provider's function to report progress with this reporter."""
+        if provider.kind != "function":
+            return provider.func
+
+        @functools.wraps(provider.func)
+        def reporting_func(*args: Any, **kwargs: Any) -> Any:
+            provider_id = self.on_provider_start(provider)
+            try:
+                result = provider.func(*args, **kwargs)
+            finally:
+                self.on_provider_end(provider_id)
+            return result
+
+        return reporting_func
+
+    def call_provider_with_reporting(
+        self, provider: Provider, values: dict[Hashable, Any]
+    ) -> Any:
+        """Call a provider and report its progress with this reporter."""
+        if provider.kind != "function":
+            return provider.call(values)
+
+        provider_id = self.on_provider_start(provider)
+        try:
+            result = provider.call(values)
+        finally:
+            self.on_provider_end(provider_id)
+        return result
+
+    def _get_provider_id(self) -> int:
+        """Return a unique identifier for a current provider."""
+        self._provider_id += 1
+        return self._provider_id
+
+
+class RichReporter(Reporter):
+    """Report progress using Rich.
+
+    This class uses the `rich <https://rich.readthedocs.io/en/stable/index.html>`_
+    package to display a progress bar.
+    Rich is not a hard dependency of Sciline and must be installed separately.
+    """
+
+    def __init__(
+        self,
+        *,
+        description: str = "Computing",
+        show_remaining_time: bool = False,
+        **rich_progress_args: Any,
+    ) -> None:
+        """Initialize a RichReporter.
+
+        Parameters
+        ----------
+        description:
+            Description shown with the progress bar.
+        show_remaining_time:
+            Show an estimate of the remaining time.
+            This is off by default because providers tend to have very different
+            running times and the estimate is unlikely to be useful.
+        rich_progress_args:
+            Additional arguments passed to the
+            `rich.Progress <https://rich.readthedocs.io/en/stable/reference/progress.html#rich.progress.Progress>`_
+            constructor.
+        """
+
+        from rich import progress
+
+        super().__init__()
+        self._description = description
+        self._show_remaining_time = show_remaining_time
+        self._progress_args = rich_progress_args
+
+        self._active_provider_list = _ProviderList()
+        self._progress_bar = _make_rich_progress_bar(
+            active_provider_list=self._active_provider_list,
+            show_remaining_time=show_remaining_time,
+            **rich_progress_args,
+        )
+        self._task_id = progress.TaskID(0)
+
+    def __enter__(self) -> None:
+        """Computation is starting."""
+        self._task_id = self._progress_bar.add_task(
+            self._description, total=self._n_steps
+        )
+        self._progress_bar.__enter__()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Computation is finished."""
+        self._progress_bar.__exit__(exc_type, exc_val, exc_tb)
+
+    def on_provider_start(self, provider: Provider) -> int:
+        """Show that a provider has started."""
+        provider_id = self._get_provider_id()
+        self._active_provider_list.add_provider(provider_id, provider)
+        return provider_id
+
+    def on_provider_end(self, provider_id: int) -> None:
+        """Show that a provider has finished."""
+        self._active_provider_list.remove_provider(provider_id)
+        self._progress_bar.update(self._task_id, advance=1)
+
+
+def _make_rich_progress_bar(
+    active_provider_list: _ProviderList,
+    show_remaining_time: bool = False,
+    **rich_progress_args: Any,
+) -> Any:
+    from rich import progress
+
+    columns = [
+        progress.TextColumn("[progress.description]{task.description}"),
+        progress.BarColumn(),
+        progress.MofNCompleteColumn(),
+        progress.TimeElapsedColumn(),
+    ]
+    if show_remaining_time:
+        columns.extend(
+            (
+                progress.RenderableColumn("|"),
+                progress.TimeRemainingColumn(),
+            )
+        )
+    columns.append(progress.RenderableColumn(active_provider_list))
+    progress_bar = progress.Progress(*columns, **rich_progress_args)
+    return progress_bar
+
+
+class NullReporter(Reporter):
+    """A progress reporter that does nothing.
+
+    Useful as a fallback to disable reporting.
+    """
+
+    def __enter__(self) -> None:
+        """Computation is starting."""
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Computation is finished."""
+
+    def on_provider_start(self, provider: Provider) -> int:
+        """Show that a provider has started."""
+        return self._get_provider_id()
+
+    def on_provider_end(self, provider_id: int) -> None:
+        """Show that a provider has finished."""
+
+    def reporting_provider_func(self, provider: Provider) -> Callable[..., Any]:
+        """Call a provider and report its progress with this reporter."""
+        # Override base method to avoid overhead.
+        return provider.func
+
+    def call_provider_with_reporting(
+        self, provider: Provider, values: dict[Hashable, Any]
+    ) -> Any:
+        """Call a provider and report its progress with this reporter."""
+        # Override base method to avoid overhead.
+        return provider.call(values)
+
+
+class _ProviderList:
+    """Track the names of currently active providers.
+
+    This class is a
+    `rich.console.Renderable https://rich.readthedocs.io/en/stable/reference/console.html#rich.console.ConsoleRenderable`
+    that displays the short names of providers.
+    """
+
+    def __init__(self) -> None:
+        self._provider_names: dict[int, str] = {}
+
+    def add_provider(self, provider_id: int, provider: Provider) -> None:
+        self._provider_names[provider_id] = provider_name(provider)
+
+    def remove_provider(self, provider_id: int) -> None:
+        del self._provider_names[provider_id]
+
+    def __rich_console__(self, console: Any, options: Any) -> Any:
+        if self._provider_names:
+            active_providers = rf"\[{', '.join(self._provider_names.values())}]"
+        else:
+            active_providers = ""
+        return console.render(active_providers, options)

--- a/src/sciline/scheduler.py
+++ b/src/sciline/scheduler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import inspect
 from collections.abc import Callable, Hashable
 from typing import Any, Protocol, runtime_checkable
@@ -7,6 +7,7 @@ from typing import Any, Protocol, runtime_checkable
 from sciline.typing import Graph
 
 from ._utils import key_full_qualname
+from .reporter import NullReporter, Reporter
 
 
 class CycleError(Exception):
@@ -19,7 +20,9 @@ class Scheduler(Protocol):
     Scheduler interface compatible with :py:class:`sciline.Pipeline`.
     """
 
-    def get(self, graph: Graph, keys: list[Hashable]) -> tuple[Any, ...]:
+    def get(
+        self, graph: Graph, keys: list[Hashable], reporter: Reporter | None = None
+    ) -> tuple[Any, ...]:
         """
         Compute the result for given keys from the graph.
 
@@ -38,8 +41,12 @@ class NaiveScheduler:
     :py:class:`DaskScheduler` instead.
     """
 
-    def get(self, graph: Graph, keys: list[Hashable]) -> tuple[Any, ...]:
+    def get(
+        self, graph: Graph, keys: list[Hashable], reporter: Reporter | None = None
+    ) -> tuple[Any, ...]:
         import graphlib
+
+        reporter = _reporter_or_fallback(reporter)
 
         dependencies = {
             tp: tuple(provider.arg_spec.keys()) for tp, provider in graph.items()
@@ -50,9 +57,11 @@ class NaiveScheduler:
             tasks = list(ts.static_order())
         except graphlib.CycleError as e:
             raise CycleError from e
+
         results: dict[Hashable, Any] = {}
-        for t in tasks:
-            results[t] = graph[t].call(results)
+        with reporter.run_computation(graph.values()):
+            for t in tasks:
+                results[t] = reporter.call_provider_with_reporting(graph[t], results)
         return tuple(results[key] for key in keys)
 
     def __repr__(self) -> str:
@@ -81,8 +90,12 @@ class DaskScheduler:
         else:
             self._dask_get = scheduler
 
-    def get(self, graph: Graph, keys: list[Hashable]) -> Any:
+    def get(
+        self, graph: Graph, keys: list[Hashable], reporter: Reporter | None = None
+    ) -> Any:
         from dask.utils import apply
+
+        reporter = _reporter_or_fallback(reporter)
 
         # Use `apply` to allow passing keyword arguments.
         # Contrary to the Dask docs, we need to pass positional args as a list
@@ -92,7 +105,7 @@ class DaskScheduler:
         dsk = {
             _to_dask_key(tp): (
                 apply,
-                provider.func,
+                reporter.reporting_provider_func(provider),
                 list(map(_to_dask_key, provider.arg_spec.args)),
                 (
                     dict,
@@ -101,12 +114,13 @@ class DaskScheduler:
             )
             for tp, provider in graph.items()
         }
-        try:
-            return self._dask_get(dsk, list(map(_to_dask_key, keys)))
-        except RuntimeError as e:
-            if str(e).startswith("Cycle detected"):
-                raise CycleError from e
-            raise
+        with reporter.run_computation(graph.values()):
+            try:
+                return self._dask_get(dsk, list(map(_to_dask_key, keys)))
+            except RuntimeError as e:
+                if str(e).startswith("Cycle detected"):
+                    raise CycleError from e
+                raise
 
     def __repr__(self) -> str:
         module = getattr(inspect.getmodule(self._dask_get), '__name__', '')
@@ -122,3 +136,9 @@ def _to_dask_key(key: Hashable) -> str:
     So this function converts Sciline keys (types) to strings.
     """
     return key_full_qualname(key)
+
+
+def _reporter_or_fallback(reporter: Reporter | None) -> Reporter:
+    if reporter is None:
+        return NullReporter()
+    return reporter

--- a/src/sciline/task_graph.py
+++ b/src/sciline/task_graph.py
@@ -7,6 +7,7 @@ from html import escape
 from typing import Any, Literal, TypeVar
 
 from ._utils import key_name
+from .reporter import Reporter
 from .scheduler import DaskScheduler, NaiveScheduler, Scheduler
 from .serialize import json_serialize_task_graph
 from .typing import Graph, Json, Key
@@ -87,7 +88,9 @@ class TaskGraph:
             )
         self._scheduler = scheduler
 
-    def compute(self, targets: Targets | None = None) -> Any:
+    def compute(
+        self, targets: Targets | None = None, reporter: Reporter | None = None
+    ) -> Any:
         """
         Compute the result of the graph.
 
@@ -97,6 +100,8 @@ class TaskGraph:
             Optional list of keys to compute. This can be used to override the keys
             stored in the graph instance. Note that the keys must be present in the
             graph as intermediate results, otherwise KeyError is raised.
+        reporter:
+            Optional reporter to track progress of this computation.
 
         Returns
         -------
@@ -107,10 +112,10 @@ class TaskGraph:
         if targets is None:
             targets = self._keys
         if isinstance(targets, tuple):
-            results = self._scheduler.get(self._graph, list(targets))
+            results = self._scheduler.get(self._graph, list(targets), reporter=reporter)
             return dict(zip(targets, results, strict=True))
         else:
-            return self._scheduler.get(self._graph, [targets])[0]
+            return self._scheduler.get(self._graph, [targets], reporter=reporter)[0]
 
     def keys(self) -> Generator[Key, None, None]:
         """

--- a/tests/reporter_test.py
+++ b/tests/reporter_test.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
+
+from types import TracebackType
+from typing import NewType, TypeVar
+
+from sciline import Pipeline, Provider, Scope
+from sciline.reporter import Reporter
+
+
+class RecordingReporter(Reporter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.active_providers: dict[int, Provider] = {}
+        self.finished_providers: dict[int, Provider] = {}
+        self.is_active = False
+        self.n_steps = -1
+
+    def __enter__(self) -> None:
+        self.n_steps = self._n_steps  # copy from parent class
+        self.is_active = True
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.is_active = False
+
+    def on_provider_start(self, provider: Provider) -> int:
+        provider_id = self._get_provider_id()
+        self.active_providers[provider_id] = provider
+        return provider_id
+
+    def on_provider_end(self, provider_id: int) -> None:
+        self.finished_providers[provider_id] = self.active_providers.pop(provider_id)
+
+
+A = NewType('A', int)
+B = NewType('B', int)
+C = NewType('C', int)
+D = NewType('D', int)
+
+
+def f1(a: A) -> B:
+    return B(a + 1)
+
+
+def f2(b: B, a: A) -> C:
+    return C(b * a)
+
+
+def f3(b: B) -> D:
+    return D(b + 2)
+
+
+def merge(*x: int) -> int:
+    return sum(x)
+
+
+def test_reporter_records_all_function_providers() -> None:
+    reporter = RecordingReporter()
+    pipeline = Pipeline((f1, f2, f3), params={A: 3})
+    result = pipeline.compute(C, reporter=reporter)
+
+    assert result == 12
+    assert reporter.n_steps == 2
+    assert not reporter.is_active
+    assert not reporter.active_providers
+
+    finished_provider_names = sorted(
+        provider.func.__name__ for provider in reporter.finished_providers.values()
+    )
+    assert finished_provider_names == ['f1', 'f2']  # f3 was not called
+
+
+def test_reporter_records_all_function_providers_map_reduce() -> None:
+    reporter = RecordingReporter()
+    pipeline = Pipeline((f1, f2, f3), params={})
+    pipeline[C] = pipeline[C].map({A: [2, 3]}).reduce(func=merge)
+    result = pipeline.compute(C, reporter=reporter)
+
+    assert result == 18
+    assert reporter.n_steps == 5
+    assert not reporter.is_active
+    assert not reporter.active_providers
+
+    finished_provider_names = sorted(
+        provider.func.__name__ for provider in reporter.finished_providers.values()
+    )
+    assert finished_provider_names == ['f1', 'f1', 'f2', 'f2', 'merge']
+
+
+T1 = NewType('T1', int)
+T2 = NewType('T2', int)
+T = TypeVar('T', T1, T2)
+
+
+class X(Scope[T, int], int): ...
+
+
+class Y(Scope[T, int], int): ...
+
+
+def g1(x: X[T]) -> Y[T]:
+    return Y[T](x + 10)
+
+
+def g2(y1: Y[T1], y2: Y[T2], a: A) -> B:
+    return B(y1 + y2 + a)
+
+
+def test_reporter_records_all_function_providers_generic() -> None:
+    reporter = RecordingReporter()
+    pipeline = Pipeline((g1, g2, f2), params={A: 3, X[T1]: 2, X[T2]: 4})
+    result = pipeline.compute(C, reporter=reporter)
+
+    assert result == 87
+    assert reporter.n_steps == 4
+    assert not reporter.is_active
+    assert not reporter.active_providers
+
+    finished_provider_names = sorted(
+        provider.func.__name__ for provider in reporter.finished_providers.values()
+    )
+    assert finished_provider_names == ['f2', 'g1', 'g1', 'g2']


### PR DESCRIPTION
This PR adds tools for showing the progress of a `Pipeline.compute` call. For now, I only implemented support for rich. But other libraries like tqdm could be added.

See also #26 which suggests to stick with Dask's own tools, in particular in Jupyter. I decided to go with this implementation because the BIFROST workflow already has a progress bar and I don't want to lose it when refactoring to use Sciline more. The BIFROST workflow currently takes ~10min and I think it is important to show that it is making progress. And it makes sense to run such a long process in a terminal outside of a Jupyter notebook for analysis.

The `Reporter` interface proposed here is flexible enough to support other kinds of reporting such as timing providers.