### PR TITLE
Add an example of inserting a custom step in a pipeline

### DIFF
--- a/docs/recipes/replacing-providers.ipynb
+++ b/docs/recipes/replacing-providers.ipynb
@@ -162,6 +162,97 @@
    "source": [
     "pipeline.compute(Result)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## Adding a custom intermediate step\n",
+    "\n",
+    "Sometimes, instead of replacing an existing provider with a new one, we wish to simply insert a new custom step in the pipeline.\n",
+    "\n",
+    "Say in our example, we wish to add an extra correction to our data between `CleanData` and `Result`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.visualize(Result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "Of course, the ideal way to do this would be to change the input type of `process`,\n",
+    "and insert a provider that takes in `CleanData` and returns the new type.\n",
+    "\n",
+    "However, we do not always have access to the provider code (when pipelines are pre-built and imported from a library),\n",
+    "and changing the input type of `process` is thus not trivial/possible.\n",
+    "\n",
+    "To be able to experiment with additional steps in a notebook,\n",
+    "a simple method is to compute the intermediate result, modify it in the notebook, and set the value back onto the pipeline.\n",
+    "\n",
+    "In our case, we wish to experiment computing the sum of the squares."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First compute the intermediate result\n",
+    "clean_data = pipeline.compute(CleanData)\n",
+    "clean_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def square(values):\n",
+    "    return [x**2 for x in values]\n",
+    "\n",
+    "# Transform the clean_data\n",
+    "data_squared = square(clean_data)\n",
+    "data_squared"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "Before setting the new values back into the pipeline, it is **highly recommended** to make a copy of the pipeline,\n",
+    "to avoid corrupting the original data and/or pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a copy of the workflow\n",
+    "new_pl = pipeline.copy()\n",
+    "\n",
+    "# Pretend that CleanData is now the squared values\n",
+    "new_pl[CleanData] = data_squared\n",
+    "\n",
+    "new_pl.compute(Result)"
+   ]
   }
  ],
  "metadata": {
@@ -179,8 +270,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding an example in the docs for adding a custom step in a pipeline when we don't have access to the original pipeline or providers code.