### PR TITLE
Do not deprecate ScopeTwoParams

### DIFF
--- a/src/sciline/domain.py
+++ b/src/sciline/domain.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from typing import Any, Generic, TypeVar, get_args, get_origin
-from warnings import warn
 
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -55,12 +54,6 @@ class ScopeTwoParams(Generic[PARAM, PARAM2, SUPER]):
     """
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        warn(
-            "ScopeTwoParams is deprecated, use Scope[P1, P2, SUPER] instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
         _check_supertype(cls, ScopeTwoParams)
         return super().__init_subclass__(**kwargs)
 


### PR DESCRIPTION
We should make a release with the new feature first and then deprecate. This will make transition easier. See, e.g., https://github.com/scipp/essreduce/pull/227.