### PR TITLE
Print path to target when input node is missing

### DIFF
--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -50,7 +50,9 @@ def _is_multiple_keys(keys: type | Iterable[type] | UnionType) -> bool:
     )
 
 
-def _build_tree_msg(graph, node, depth=0, max_depth=4, indent='    '):
+def _build_tree_msg(
+    graph: Any, node: Any, depth: int = 0, max_depth: int = 4, indent: str = '    '
+) -> str:
     """Build a tree message showing dependencies recursively.
 
     Parameters

--- a/src/sciline/pipeline.py
+++ b/src/sciline/pipeline.py
@@ -77,14 +77,12 @@ def _find_paths_to_targets(
     for target in targets:
         try:
             # Find all simple paths from the missing node to the target
-            target_paths = list(all_simple_paths(graph, missing, target))
-            # Sort by length to show the shortest path first
-            paths.extend(sorted(target_paths, key=len))
+            paths.extend(list(all_simple_paths(graph, missing, target)))
         except (nx.NetworkXNoPath, nx.NodeNotFound):  # noqa: PERF203
             # No path found or nodes not in graph
             continue
 
-    return paths
+    return sorted(paths, key=len)  # Sort by length to show the shortest path first
 
 
 def _format_paths_msg(nx_graph: Any, paths: list[list[Any]]) -> str:

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -10,7 +10,6 @@ import numpy.typing as npt
 import pytest
 
 import sciline as sl
-from sciline._utils import key_name
 
 
 def int_to_float(x: int) -> float:
@@ -1478,7 +1477,7 @@ def test_output_keys_method() -> None:
 
 
 @pytest.mark.parametrize('get_method', ['get', 'compute'])
-def test_output_keys_in_not_found_error_message(get_method: str) -> None:
+def test_missing_input_error(get_method: str) -> None:
     def make_float() -> float:
         return 1.0
 
@@ -1486,7 +1485,26 @@ def test_output_keys_in_not_found_error_message(get_method: str) -> None:
         return "a string"
 
     pl = sl.Pipeline([make_float, make_str])
-    with pytest.raises(sl.handler.UnsatisfiedRequirement) as info:
+    with pytest.raises(
+        sl.handler.UnsatisfiedRequirement, match="Missing input node 'int'"
+    ):
         getattr(pl, get_method)(int)
-    for key in pl.output_keys():
-        assert key_name(key) in info.value.args[0]
+    with pytest.raises(
+        sl.handler.UnsatisfiedRequirement, match="Missing input node 'int'"
+    ):
+        getattr(pl, get_method)(str)
+
+
+@pytest.mark.parametrize('get_method', ['get', 'compute'])
+def test_not_in_graph_error(get_method: str) -> None:
+    def make_float() -> float:
+        return 1.0
+
+    def make_str(x: int) -> str:
+        return "a string"
+
+    pl = sl.Pipeline([make_float, make_str])
+    with pytest.raises(
+        sl.handler.UnsatisfiedRequirement, match="Requested node not in graph"
+    ):
+        getattr(pl, get_method)(bool)


### PR DESCRIPTION
This avoids printing possibly hundreds of types. I think the old implementation was mainly meant for case 2 below, but case 1 feels more common in practice. We now print ~a little "tree"~ the path from the missing node to the target node, e.g.,:

```
UnsatisfiedRequirement: Missing input node 'Filename'. Affects requested targets (via providers given in parentheses):
1. Filename → (__main__.load) → RawData → (__main__.clean) → CleanedData → (__main__.process) → Result
```

Try it out, e.g., with the "Getting Started" notebook:

Case 1: Remove the `Filename` param and try to compute `Result`
Case 2: Try to compute something not in the graph, such as `int`