### PR TITLE
Annotate exceptions with arg types

### DIFF
--- a/src/sciline/_provider.py
+++ b/src/sciline/_provider.py
@@ -139,9 +139,18 @@ class Provider:
             f"func={self._func})"
         )
 
-    def call(self, values: dict[Hashable, Any]) -> Any:
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Call the provider."""
+        try:
+            return self._func(*args, **kwargs)
+        except Exception as e:
+            name = f"{self.location.module}.{self.location.name}"
+            e.add_note(f"In provider {self._arg_spec.format_signature(name)}")
+            raise
+
+    def call_arg_dict(self, values: dict[Hashable, Any]) -> Any:
         """Call the provider with arguments extracted from ``values``."""
-        return self._func(
+        return self(
             *(values[arg] for arg in self._arg_spec.args),
             **{key: values[arg] for key, arg in self._arg_spec.kwargs},
         )
@@ -215,13 +224,37 @@ class ArgSpec:
         """Bind concrete types to TypeVars."""
         return self.map_keys(lambda arg: _bind_free_typevars(arg, bound=bound))
 
-    def map_keys(self, transform: Callable[[Key], Key]) -> ArgSpec:
+    def map_keys(
+        self, transform: Callable[[Key], Key], *, map_return: bool = True
+    ) -> ArgSpec:
         """Return a new ArgSpec with the keys mapped by ``callback``."""
+        return_ = (
+            self._return
+            if self._return is None or not map_return
+            else transform(self._return)
+        )
         return ArgSpec(
             args={name: transform(arg) for name, arg in self._args.items()},
             kwargs={name: transform(arg) for name, arg in self._kwargs.items()},
-            return_=self._return if self._return is None else transform(self._return),
+            return_=return_,
         )
+
+    def format_signature(self, fn_name: str) -> str:
+        """Format self as a function signature."""
+        args = ",\n    ".join(f"{name}: {arg}" for name, arg in self._args.items())
+        kwargs = ",\n    ".join(f"{name}: {arg}" for name, arg in self._kwargs.items())
+
+        full_args = args
+        if kwargs:
+            if full_args:
+                full_args += ",\n    "
+            full_args += f"*,\n    {kwargs},"
+
+        if full_args:
+            return f"""{fn_name}(
+    {full_args},
+) -> {self._return}"""
+        return f"{fn_name}() -> {self._return}"
 
 
 @dataclass

--- a/src/sciline/_utils.py
+++ b/src/sciline/_utils.py
@@ -60,7 +60,7 @@ def provider_name(provider: Provider) -> str:
     if provider.kind == 'function':
         return provider.func.__name__
     if provider.kind == 'parameter':
-        return f'parameter({key_name(type(provider.call({})))})'
+        return f'parameter({key_name(type(provider.call_arg_dict({})))})'
     return str(provider)
 
 
@@ -68,5 +68,5 @@ def provider_full_qualname(provider: Provider) -> str:
     if provider.kind == 'function':
         return full_qualname(provider.func)
     if provider.kind == 'parameter':
-        return f'parameter({key_full_qualname(type(provider.call({})))})'
+        return f'parameter({key_full_qualname(type(provider.call_arg_dict({})))})'
     return str(provider)

--- a/src/sciline/data_graph.py
+++ b/src/sciline/data_graph.py
@@ -279,7 +279,7 @@ def to_task_graph(
             new_key = dict(zip(orig_keys, input_nodes, strict=True))
             # By using map_keys (instead of creating an ArgSpec from scratch),
             # we automatically preserve what args and kwargs are.
-            spec = provider.arg_spec.map_keys(new_key.get)
+            spec = provider.arg_spec.map_keys(new_key.get, map_return=False)
             if len(spec) != len(input_nodes):
                 # This should be caught by __setitem__, but we check here to be safe.
                 raise ValueError("Corrupted graph")

--- a/src/sciline/reporter.py
+++ b/src/sciline/reporter.py
@@ -84,13 +84,13 @@ class Reporter(ABC):
     def reporting_provider_func(self, provider: Provider) -> Callable[..., Any]:
         """Wrap a provider's function to report progress with this reporter."""
         if provider.kind != "function":
-            return provider.func
+            return provider
 
-        @functools.wraps(provider.func)
+        @functools.wraps(provider)
         def reporting_func(*args: Any, **kwargs: Any) -> Any:
             provider_id = self.on_provider_start(provider)
             try:
-                result = provider.func(*args, **kwargs)
+                result = provider(*args, **kwargs)
             finally:
                 self.on_provider_end(provider_id)
             return result
@@ -102,11 +102,11 @@ class Reporter(ABC):
     ) -> Any:
         """Call a provider and report its progress with this reporter."""
         if provider.kind != "function":
-            return provider.call(values)
+            return provider.call_arg_dict(values)
 
         provider_id = self.on_provider_start(provider)
         try:
-            result = provider.call(values)
+            result = provider.call_arg_dict(values)
         finally:
             self.on_provider_end(provider_id)
         return result
@@ -388,14 +388,14 @@ class NullReporter(Reporter):
     def reporting_provider_func(self, provider: Provider) -> Callable[..., Any]:
         """Call a provider and report its progress with this reporter."""
         # Override base method to avoid overhead.
-        return provider.func
+        return provider
 
     def call_provider_with_reporting(
         self, provider: Provider, values: dict[Hashable, Any]
     ) -> Any:
         """Call a provider and report its progress with this reporter."""
         # Override base method to avoid overhead.
-        return provider.call(values)
+        return provider.call_arg_dict(values)
 
 
 class _ProviderList:

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1746,6 +1746,11 @@ def test_not_in_graph_error(get_method: str) -> None:
 
 
 def test_errors_are_annotated(scheduler: sl.scheduler.Scheduler) -> None:
+    if 'distributed' in repr(scheduler):
+        # This test does not work with the distributed scheduler because
+        # `func` cannot be pickled because `G` and `H` are local to this function.
+        return
+
     A = NewType('A', int)
     B = NewType('B', int)
     T = TypeVar('T', A, B)

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
 import functools
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Generic, NewType, TypeVar
@@ -1742,3 +1743,32 @@ def test_not_in_graph_error(get_method: str) -> None:
         sl.handler.UnsatisfiedRequirement, match="Requested node not in graph"
     ):
         getattr(pl, get_method)(bool)
+
+
+def test_errors_are_annotated(scheduler: sl.scheduler.Scheduler) -> None:
+    A = NewType('A', int)
+    B = NewType('B', int)
+    T = TypeVar('T', A, B)
+
+    class G(sl.Scope[T, int], int): ...
+
+    class H(sl.Scope[T, int], int): ...
+
+    def foo(g: G[T]) -> H[T]:
+        raise RuntimeError("provider failed")
+        return H[T](g)
+
+    pl = sl.Pipeline([foo], params={G[A]: G[A](2), G[B]: G[B](3)})
+    with pytest.raises(RuntimeError) as err:
+        pl.compute(H[B], scheduler=scheduler)
+    assert "provider failed" in err.value.args
+
+    [note] = err.value.__notes__
+    # The regex is not sensitive to indentation and the module name this test is in.
+    assert re.search(
+        r"""foo\(
+.*test_errors_are_annotated\.<locals>\.G\[.*pipeline_test\.B],
+\) -> .*test_errors_are_annotated\.<locals>\.H\[.*pipeline_test\.B]""",
+        note,
+        flags=re.MULTILINE,
+    )


### PR DESCRIPTION
This PR adds an exception note to exceptions from providers that indicates the argument types. It is related to #74

For generic providers in particular, it can be difficult to find out where exactly an exception comes from. With this change, we get the full signature of the failing function with concrete (i.e., not generic) types. For example:
```python
from typing import NewType, TypeVar

import sciline as sl

A = NewType('A', int)
B = NewType('B', int)
C = NewType('C', int)
T = TypeVar('T', A, B, C)

class G(sl.Scope[T, int], int): ...
class H(sl.Scope[T, int], int): ...
class I(sl.Scope[T, int], int): ...


def f1(g: G[T]) -> H[T]:
    return H[T](g * 2)


def f2(g: G[A], h: H[T]) -> I[T]:
    raise RuntimeError("Bad input")
    return I[T](g + h)

pl = sl.Pipeline([f1, f2], params={G[A]: 2, G[B]: 3})
pl.compute(I[B])
```
The exception gets formatted (Python 3.11) as
```python
  File ".../errors.py", line 23, in f2
    raise RuntimeError("Bad input")
RuntimeError: Bad input
In provider __main__.f2(
    g: __main__.G[__main__.A],
    h: __main__.H[__main__.B],
) -> __main__.I[__main__.B]
```