### PR TITLE
Add NativeScope for single-base native types

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -11,6 +11,7 @@
    :recursive:
 
    Pipeline
+   NativeScope
    Scope
    scheduler.Scheduler
    scheduler.DaskScheduler
@@ -29,6 +30,7 @@
 
    compute_mapped
    get_mapped_node_names
+   native_scope
 ```
 
 ## Exceptions

--- a/src/sciline/__init__.py
+++ b/src/sciline/__init__.py
@@ -11,7 +11,7 @@ except importlib.metadata.PackageNotFoundError:
 
 from . import scheduler
 from ._provider import Provider, UnboundTypeVar
-from .domain import Scope
+from .domain import NativeScope, Scope, native_scope
 from .handler import (
     HandleAsBuildTimeException,
     HandleAsComputeTimeException,
@@ -23,6 +23,7 @@ from .task_graph import TaskGraph
 __all__ = [
     "HandleAsBuildTimeException",
     "HandleAsComputeTimeException",
+    "NativeScope",
     "Pipeline",
     "Provider",
     "Scope",
@@ -31,6 +32,7 @@ __all__ = [
     "UnsatisfiedRequirement",
     "compute_mapped",
     "get_mapped_node_names",
+    "native_scope",
     "scheduler",
 ]
 

--- a/src/sciline/domain.py
+++ b/src/sciline/domain.py
@@ -1,10 +1,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
-from typing import Any, Generic, TypeVar, TypeVarTuple, get_args, get_origin
+from types import GenericAlias, NoneType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ForwardRef,
+    Generic,
+    TypeVar,
+    TypeVarTuple,
+    get_args,
+    get_origin,
+)
 
 PARAM = TypeVar("PARAM")
 PARAMS = TypeVarTuple("PARAMS")
 SUPER = TypeVar("SUPER")
+NATIVE_SCOPE = TypeVar("NATIVE_SCOPE")
+_TYPE_VAR_TUPLE = type(PARAMS)
 
 
 def _check_supertype(cls: type, scope_cls: type) -> None:
@@ -42,3 +54,134 @@ class Scope(Generic[*PARAMS, SUPER]):
 
     def __new__(cls, x: SUPER) -> SUPER:  # type: ignore[misc]
         return x
+
+
+class _NativeScopeBase:
+    def __init__(self, args: tuple[Any, ...]) -> None:
+        self.args = args
+
+    def __mro_entries__(self, bases: tuple[object, ...]) -> tuple[()]:
+        return ()
+
+
+if TYPE_CHECKING:
+
+    class NativeScope(Generic[*PARAMS, SUPER]):
+        """Static typing interface for :func:`native_scope`."""
+
+        def __new__(cls, x: SUPER) -> SUPER: ...  # type: ignore[misc]
+
+else:
+
+    class NativeScope:
+        """
+        Erased base class for defining a scoped native type.
+
+        Use it with :func:`native_scope` as the first base class:
+
+        .. code-block:: python
+
+            @sciline.native_scope
+            class NeXusData(
+                sciline.NativeScope[RunType, sc.DataArray], sc.DataArray
+            ):
+                pass
+
+        The ``NativeScope`` base is erased during class creation, so
+        ``NeXusData`` has only ``sc.DataArray`` as a runtime base.
+        """
+
+        @classmethod
+        def __class_getitem__(cls, args: Any) -> _NativeScopeBase:
+            if not isinstance(args, tuple):
+                args = (args,)
+            return _NativeScopeBase(args)
+
+
+def _native_scope_getitem(cls: type, args: Any) -> GenericAlias:
+    if not isinstance(args, tuple):
+        args = (args,)
+    args = tuple(
+        NoneType if arg is None else ForwardRef(arg) if isinstance(arg, str) else arg
+        for arg in args
+    )
+    parameters = getattr(cls, '__parameters__', ())
+    for parameter in parameters:
+        if prepare_subst := getattr(parameter, '__typing_prepare_subst__', None):
+            args = prepare_subst(cls, args)
+    if not parameters:
+        raise TypeError(f"{cls} is not a generic class")
+    if len(args) != len(parameters):
+        kind = 'many' if len(args) > len(parameters) else 'few'
+        raise TypeError(
+            f"Too {kind} arguments for {cls}; actual {len(args)}, "
+            f"expected {len(parameters)}"
+        )
+    args = tuple(
+        item
+        for parameter, argument in zip(parameters, args, strict=True)
+        for item in (
+            argument if isinstance(parameter, _TYPE_VAR_TUPLE) else (argument,)
+        )
+    )
+    return GenericAlias(cls, args)
+
+
+def _native_scope_new(cls: type, x: Any) -> Any:
+    return x
+
+
+def native_scope(cls: type[NATIVE_SCOPE]) -> type[NATIVE_SCOPE]:
+    """
+    Turn a :class:`NativeScope` declaration into a generic, identity key.
+
+    Apply this decorator to a class whose first base is ``NativeScope`` and
+    whose remaining direct base is its value type:
+
+    .. code-block:: python
+
+        @sciline.native_scope
+        class NeXusData(
+            sciline.NativeScope[RunType, sc.DataArray], sc.DataArray
+        ):
+            pass
+
+    Both ``NeXusData[RunType](data)`` and ``NeXusData(data)`` return ``data``
+    unchanged. Type checkers retain the generic ``NativeScope`` declaration.
+
+    ``NativeScope`` is erased while the class is defined, allowing the remaining
+    base to be a native type that does not support multiple inheritance.
+    """
+    orig_bases = cls.__dict__.get('__orig_bases__', ())
+    scope = orig_bases[0] if orig_bases else None
+    if not isinstance(scope, _NativeScopeBase):
+        raise TypeError(
+            f"Missing NativeScope declaration for {cls}.\n"
+            "Example:\n"
+            "\n"
+            "    @sl.native_scope\n"
+            "    class A(sl.NativeScope[Param, float], float):\n"
+            "        ...\n"
+        )
+    if not scope.args:
+        raise TypeError(f"NativeScope declaration for {cls} has no interface type")
+
+    supertype = scope.args[-1]
+    supertype = getattr(supertype, '__origin__', None) or supertype
+    if supertype not in cls.__bases__:
+        raise TypeError(
+            f"Missing or wrong interface for {cls}, should inherit {supertype}.\n"
+            "Example:\n"
+            "\n"
+            "    @sl.native_scope\n"
+            "    class A(sl.NativeScope[Param, float], float):\n"
+            "        ...\n"
+        )
+
+    parameters = '__parameters__'
+    setattr(cls, parameters, GenericAlias(cls, scope.args[:-1]).__parameters__)
+    class_getitem = '__class_getitem__'
+    setattr(cls, class_getitem, classmethod(_native_scope_getitem))
+    new = '__new__'
+    setattr(cls, new, staticmethod(_native_scope_new))
+    return cls

--- a/tests/domain_test.py
+++ b/tests/domain_test.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from typing import NewType, TypeVar
+import sys
+from typing import NewType, TypeVar, TypeVarTuple, get_args, get_origin
 
 import pytest
 
@@ -9,11 +10,26 @@ import sciline as sl
 T = TypeVar("T")
 
 
+class _NativeBase:
+    pass
+
+
 def test_mypy_detects_wrong_arg_type_of_Scope_subclass() -> None:
     Param = TypeVar('Param')
     Param1 = NewType('Param1', int)
 
     class A(sl.Scope[Param, float], float): ...
+
+    A[Param1](1.5)
+    A[Param1]('abc')  # type: ignore[arg-type]
+
+
+def test_mypy_detects_wrong_arg_type_of_NativeScope_subclass() -> None:
+    Param = TypeVar('Param')
+    Param1 = NewType('Param1', int)
+
+    @sl.native_scope
+    class A(sl.NativeScope[Param, float], float): ...
 
     A[Param1](1.5)
     A[Param1]('abc')  # type: ignore[arg-type]
@@ -61,3 +77,111 @@ def test_Scope_two_params() -> None:
     class A(sl.Scope[Param1, Param2, float], float): ...
 
     assert isinstance(A[int, int](1.5), float)
+
+
+def test_native_scope_alias_preserves_generic_key_and_value() -> None:
+    Param = TypeVar('Param')
+
+    @sl.native_scope
+    class A(sl.NativeScope[Param, _NativeBase], _NativeBase):
+        pass
+
+    value = _NativeBase()
+    key = A[int]
+    assert A.__bases__ == (_NativeBase,)
+    assert get_origin(key) is A
+    assert get_args(key) == (int,)
+    assert get_args(A[None]) == (type(None),)
+    assert get_args(A['int'])[0].__forward_arg__ == 'int'
+    assert key(value) is value
+    assert A(x=value) is value
+
+
+def test_native_scope_rejects_wrong_number_of_type_arguments() -> None:
+    Param = TypeVar('Param')
+
+    @sl.native_scope
+    class A(sl.NativeScope[Param, _NativeBase], _NativeBase):
+        pass
+
+    with pytest.raises(TypeError, match="Too few arguments"):
+        A[()]  # type: ignore[misc]
+    with pytest.raises(TypeError, match="Too many arguments"):
+        A[int, str]  # type: ignore[misc]
+
+    @sl.native_scope
+    class B(sl.NativeScope[_NativeBase], _NativeBase):
+        pass
+
+    with pytest.raises(TypeError, match="is not a generic class"):
+        B[()]  # type: ignore[misc]
+
+
+def test_native_scope_supports_variadic_scope_parameters() -> None:
+    Params = TypeVarTuple('Params')
+
+    @sl.native_scope
+    class A(sl.NativeScope[*Params, _NativeBase], _NativeBase):
+        pass
+
+    assert get_args(A[()]) == ()
+    assert get_args(A[int, str]) == (int, str)
+
+
+def test_native_scope_inconsistent_type_and_interface_raises() -> None:
+    Param = TypeVar('Param')
+
+    with pytest.raises(TypeError, match="Missing or wrong interface for"):
+
+        @sl.native_scope
+        class A(sl.NativeScope[Param, str], _NativeBase):
+            pass
+
+
+def test_native_scope_keys_work_in_pipeline() -> None:
+    Sample = NewType('Sample', int)
+    Background = NewType('Background', int)
+    Run = TypeVar('Run', Sample, Background)
+    Detector = NewType('Detector', int)
+    Monitor = NewType('Monitor', int)
+    Component = TypeVar('Component', Detector, Monitor)
+
+    @sl.native_scope
+    class Raw(sl.NativeScope[Component, Run, _NativeBase], _NativeBase):
+        pass
+
+    @sl.native_scope
+    class Processed(sl.NativeScope[Component, Run, _NativeBase], _NativeBase):
+        pass
+
+    def process(data: Raw[Component, Run]) -> Processed[Component, Run]:
+        return Processed[Component, Run](data)
+
+    value = _NativeBase()
+    pipeline = sl.Pipeline([process], params={Raw[Detector, Sample]: value})
+    assert pipeline.compute(Processed[Detector, Sample]) is value
+
+
+def test_native_scope_generic_key_is_automatically_specialized() -> None:
+    Param = TypeVar('Param', int, float)
+
+    @sl.native_scope
+    class A(sl.NativeScope[Param, _NativeBase], _NativeBase):
+        pass
+
+    value = _NativeBase()
+    pipeline = sl.Pipeline(params={A: value})
+    assert pipeline.compute(A[int]) is value
+    assert pipeline.compute(A[float]) is value
+
+
+if sys.version_info >= (3, 13):
+
+    def test_native_scope_applies_default_type_arguments() -> None:
+        Param = TypeVar('Param', default=int)
+
+        @sl.native_scope
+        class A(sl.NativeScope[Param, _NativeBase], _NativeBase):
+            pass
+
+        assert get_args(A[()]) == (int,)


### PR DESCRIPTION
Provide a runtime-erased NativeScope base and native_scope decorator for generic identity keys around extension types that cannot support multiple inheritance. Preserve Scope-compatible specialization and add API coverage.