### PR TITLE
fix: Keep requested keys alive in the naive scheduler

### DIFF
--- a/src/sciline/scheduler.py
+++ b/src/sciline/scheduler.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import inspect
 from collections import Counter
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Container, Hashable
 from typing import Any, Protocol, runtime_checkable
 
 from sciline.typing import Graph
@@ -61,11 +61,12 @@ class NaiveScheduler:
             raise CycleError from e
 
         dependents = _count_dependents(dependencies)
+        requested = set(keys)
         results: dict[Hashable, Any] = {}
         with reporter.run_computation(graph.values()):
             for t in tasks:
                 results[t] = reporter.call_provider_with_reporting(graph[t], results)
-                _consume_arguments(graph[t], dependents, results)
+                _consume_arguments(graph[t], dependents, results, requested)
 
         return tuple(results[key] for key in keys)
 
@@ -81,11 +82,19 @@ def _count_dependents(dependencies: dict[type, tuple[type, ...]]) -> Counter[typ
 
 
 def _consume_arguments(
-    provider: Provider, counts: Counter[type], results: dict[Hashable, object]
+    provider: Provider,
+    counts: Counter[type],
+    results: dict[Hashable, object],
+    requested: Container[Hashable],
 ) -> None:
+    """Discard results that no remaining provider needs.
+
+    Requested keys are kept: they are returned to the caller, so their consumer
+    count reaching zero does not mean they are no longer needed.
+    """
     for arg in provider.arg_spec.keys():
         counts[arg] -= 1
-        if counts[arg] == 0:
+        if counts[arg] == 0 and arg not in requested:
             del results[arg]
 
 

--- a/src/sciline/scheduler.py
+++ b/src/sciline/scheduler.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import inspect
 from collections import Counter
-from collections.abc import Callable, Container, Hashable
+from collections.abc import Callable, Hashable
 from typing import Any, Protocol, runtime_checkable
 
 from sciline.typing import Graph
@@ -85,7 +85,7 @@ def _consume_arguments(
     provider: Provider,
     counts: Counter[type],
     results: dict[Hashable, object],
-    requested: Container[Hashable],
+    requested: set[Hashable],
 ) -> None:
     """Discard results that no remaining provider needs.
 

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -879,6 +879,20 @@ def test_compute_with_NaiveScheduler() -> None:
     assert res == 1.5
 
 
+def test_compute_returns_requested_key_that_another_requested_key_depends_on(
+    scheduler: sl.scheduler.Scheduler,
+) -> None:
+    def make_int_local() -> int:
+        return 3
+
+    def int_to_float_local(x: int) -> float:
+        return 0.5 * x
+
+    pipeline = sl.Pipeline([int_to_float_local, make_int_local])
+    # int is both a requested key and an argument of the provider of float.
+    assert pipeline.compute((int, float), scheduler=scheduler) == {int: 3, float: 1.5}
+
+
 def test_bind_and_call_no_function() -> None:
     pipeline = sl.Pipeline([make_int])
     assert pipeline.bind_and_call(()) == ()


### PR DESCRIPTION
`NaiveScheduler` frees an intermediate result as soon as every provider consuming it has run. The consumer count is built from the graph's providers only, so a key that is both requested and consumed by another task reaches zero and is deleted before it can be returned:

```python
A = NewType('A', int)
B = NewType('B', int)

def make_b(a: A) -> B:
    return B(a + 1)

pl = sciline.Pipeline((make_b,))
pl[A] = 1

pl.compute((A, B))                                    # dask:  {A: 1, B: 2}
pl.get((A, B), scheduler=NaiveScheduler()).compute()  # naive: KeyError(A)
```

Any compute for several targets where one target depends on another is affected; the dask scheduler is not. The regression came in with a5c9a08 ("Discard data early in naive scheduler") and is in 26.8.0, so 25.11.1 and earlier are fine.

Counting the requested keys as consumers keeps them alive until they are returned, and everything else is still discarded as early as before.

This was found from downstream fallout rather than from reading the code: ESSlivedata defaults its services to the naive scheduler, and there both detector-view construction and monitor workflow cycles fail with a `KeyError` on a live key. `ess.reduce.streaming.StreamProcessor` hits the pattern routinely, computing several targets at once where one feeds another. With this fix those workflows run again under the naive scheduler.

Test plan: the new test runs on all three scheduler fixtures and fails only on `[naive]` without the fix.
